### PR TITLE
Add a RESTful API for external configuration

### DIFF
--- a/.github/workflows/server_tests.yml
+++ b/.github/workflows/server_tests.yml
@@ -44,10 +44,9 @@ jobs:
         working-directory: ./server
       - name: Run tests
         working-directory: ./server
-        run: VENUELESS_REDIS_HOST=redis VENUELESS_DB_TYPE=postgresql VENUELESS_DB_NAME=venueless VENUELESS_DB_USER=venueless VENUELESS_DB_PASS=venueless VENUELESS_DB_HOST=postgres py.test tests/ --cov=./ --cov-report=xml --reuse-db
+        run: VENUELESS_REDIS_HOST=redis VENUELESS_DB_TYPE=postgresql VENUELESS_DB_NAME=venueless VENUELESS_DB_USER=venueless VENUELESS_DB_PASS=venueless VENUELESS_DB_HOST=postgres py.test tests/ --cov=./ --cov-report=xml
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
           file: server/coverage.xml
           fail_ci_if_error: true
-

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -16,3 +16,8 @@ a:hover {
 .wy-menu-vertical a {
     color: #d9d9d9;
 }
+@media screen and (min-width: 480px) {
+    .wy-table-responsive table.rest-resource-table td, .wy-table-responsive table.rest-resource-table th {
+        white-space: normal;
+    }
+}

--- a/docs/developer/api/world.rst
+++ b/docs/developer/api/world.rst
@@ -1,10 +1,11 @@
 World configuration
 ===================
 
-The world configuration is pushed directly after authentication with a message structured as::
+The world configuration is pushed to the client first as part of the successful authentication response.
+If the world config changes, you will get an update like this::
 
-    <- ["world.config", { … }]
-    
+    <= ["world.update", { … }]
+
 The body of the configuration is structured like this, filtered to user visibility:
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,3 +9,4 @@ Welcome to venueless' documentation!
 
    admin/index
    developer/index
+   rest/index

--- a/docs/rest/fundamentals.rst
+++ b/docs/rest/fundamentals.rst
@@ -1,0 +1,94 @@
+Basic concepts
+==============
+
+This page describes basic concepts and definition that you need to know to interact with venueless' public REST API,
+such as authentication, pagination and similar definitions.
+
+.. _`rest-auth`:
+
+Authentication
+--------------
+
+To access the API, you need to present valid authentication credentials. These credentials currently take the form
+of an JWT token that is issued by a valid identity provider for a given world. The API currently does not allow
+any access across the scope of one world.
+
+You can send your authorization token in the ``Authorization`` Header::
+
+    Authorization: Bearer myverysecretjwttoken
+
+Accessing the API requires that your JWT token is granted at least the ``world.api`` permission.
+
+Pagination
+----------
+
+Most lists of objects returned by venueless' API will be paginated. The response will take the form of:
+
+.. sourcecode:: javascript
+
+    {
+        "count": 117,
+        "next": "https://world.venueless.org/api/v1/organizers/?page=2",
+        "previous": null,
+        "results": […],
+    }
+
+As you can see, the response contains the total number of results in the field ``count``.
+The fields ``next`` and ``previous`` contain links to the next and previous page of results,
+respectively, or ``null`` if there is no such page. You can use those URLs to retrieve the
+respective page.
+
+The field ``results`` contains a list of objects representing the first results. For most
+objects, every page contains 50 results.
+
+Errors
+------
+
+Error responses (of type 400-499) are returned in one of the following forms, depending on
+the type of error. General errors look like:
+
+.. sourcecode:: http
+
+   HTTP/1.1 405 Method Not Allowed
+   Content-Type: application/json
+   Content-Length: 42
+
+   {"detail": "Method 'DELETE' not allowed."}
+
+Field specific input errors include the name of the offending fields as keys in the response:
+
+.. sourcecode:: http
+
+   HTTP/1.1 400 Bad Request
+   Content-Type: application/json
+   Content-Length: 94
+
+   {"amount": ["A valid integer is required."], "description": ["This field may not be blank."]}
+
+Data types
+----------
+
+All structured API responses are returned in JSON format using standard JSON data types such
+as integers, floating point numbers, strings, lists, objects and booleans. Most fields can
+be ``null`` as well.
+
+The following table shows some data types that have no native JSON representation and how
+we serialize them to JSON.
+
+===================== ============================ ===================================
+Internal type         JSON representation          Examples
+===================== ============================ ===================================
+Datetime              String in ISO 8601 format    ``"2017-12-27T10:00:00Z"``
+                      with timezone (normally UTC) ``"2017-12-27T10:00:00.596934Z"``,
+                                                   ``"2017-12-27T10:00:00+02:00"``
+Date                  String in ISO 8601 format    ``2017-12-27``
+===================== ============================ ===================================
+
+Query parameters
+^^^^^^^^^^^^^^^^
+
+Most list endpoints allow a filtering of the results using query parameters. In this case, booleans should be passed
+as the string values ``true`` and ``false``.
+
+If the ``ordering`` parameter is documented for a resource, you can use it to sort the result set by one of the allowed
+fields. Prepend a ``-`` to the field name to reverse the sort order.

--- a/docs/rest/index.rst
+++ b/docs/rest/index.rst
@@ -1,0 +1,11 @@
+REST API
+========
+
+Welcome to our REST API documentation!
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   fundamentals
+   resources/index

--- a/docs/rest/resources/index.rst
+++ b/docs/rest/resources/index.rst
@@ -1,0 +1,9 @@
+API resources
+=============
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   world
+   room

--- a/docs/rest/resources/room.rst
+++ b/docs/rest/resources/room.rst
@@ -1,0 +1,222 @@
+Room
+====
+
+Resource description
+--------------------
+
+The world resource contains the following public fields:
+
+.. rst-class:: rest-resource-table
+
+===================================== ========================== =======================================================
+Field                                 Type                       Description
+===================================== ========================== =======================================================
+id                                    string                     The world's ID
+name                                  string                     A title for the room
+description                           string                     A markdown-compatible description of the room
+module_config                         list                       Room content configuration
+permission_config                     object                     Permission rules mapping permission keys to lists of
+                                                                 traits
+sorting_priority                      integer                    An arbitrary integer used for sorting
+===================================== ========================== =======================================================
+
+Endpoints
+---------
+
+.. http:get:: /api/v1/worlds/(world_id)/rooms/
+
+   Returns all rooms in the world (that you are allowed to see)
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /api/v1/worlds/sample/rooms/ HTTP/1.1
+      Accept: application/json, text/javascript
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "count": 1,
+        "next": null,
+        "previous": null,
+        "results": [
+          {
+            "id": "eaa91024-1278-468d-8f24-31479817b073",
+            "name": "Forum",
+            "description": "Main room",
+            "module_config": [
+              {
+                "type": "chat.native"
+              }
+            ],
+            "permission_config": {},
+            "domain": "sample.venueless.events"
+          }
+        ]
+      }
+
+   :statuscode 200: no error
+   :statuscode 401: Authentication failure
+   :statuscode 403: The world or room does not exist **or** you have no permission to view it.
+
+.. http:get:: /api/v1/worlds/(world_id)/rooms/(room_id)/
+
+   Returns details on a specific room
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /api/v1/worlds/sample/rooms/eaa91024-1278-468d-8f24-31479817b073/ HTTP/1.1
+      Accept: application/json, text/javascript
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "id": "eaa91024-1278-468d-8f24-31479817b073",
+        "name": "Forum",
+        "description": "Main room",
+        "module_config": [
+          {
+            "type": "chat.native"
+          }
+        ],
+        "permission_config": {},
+        "domain": "sample.venueless.events"
+      }
+
+   :statuscode 200: no error
+   :statuscode 401: Authentication failure
+   :statuscode 403: The world or room does not exist **or** you have no permission to view it.
+
+.. http:post:: /api/v1/worlds/(world_id)/rooms/
+
+   Creates a room
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      POST /api/v1/worlds/sample/ HTTP/1.1
+      Accept: application/json, text/javascript
+      Content-Type: application/json
+
+      {
+        "name": "Quiet room",
+        "description": "Main room",
+        "module_config": [
+          {
+            "type": "chat.native"
+          }
+        ],
+        "permission_config": {},
+        "domain": "sample.venueless.events"
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "id": "eaa91024-1278-468d-8f24-31479817b073",
+        "name": "Quiet room",
+        "description": "Main room",
+        "module_config": [
+          {
+            "type": "chat.native"
+          }
+        ],
+        "permission_config": {},
+        "domain": "sample.venueless.events"
+      }
+
+   :statuscode 200: no error
+   :statuscode 400: The world could not be updated due to invalid submitted data.
+   :statuscode 401: Authentication failure
+   :statuscode 403: The requested world does not exist **or** you have no permission to create this resource.
+
+.. http:patch:: /api/v1/worlds/(world_id)/rooms/(room_id)/
+
+   Updates a room
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      PATCH /api/v1/worlds/sample/ HTTP/1.1
+      Accept: application/json, text/javascript
+      Content-Type: application/json
+
+      {
+        "name": "Quiet room"
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "id": "eaa91024-1278-468d-8f24-31479817b073",
+        "name": "Quiet room",
+        "description": "Main room",
+        "module_config": [
+          {
+            "type": "chat.native"
+          }
+        ],
+        "permission_config": {},
+        "domain": "sample.venueless.events"
+      }
+
+   :statuscode 200: no error
+   :statuscode 400: The world could not be updated due to invalid submitted data.
+   :statuscode 401: Authentication failure
+   :statuscode 403: The requested world/room does not exist **or** you have no permission to update this resource.
+
+.. http:delete:: /api/v1/worlds/(world_id)/rooms/(room_id)/
+
+   Deletes a room
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      PATCH /api/v1/worlds/sample/ HTTP/1.1
+      Accept: application/json, text/javascript
+      Content-Type: application/json
+
+      {
+        "name": "Quiet room"
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+      Vary: Accept
+
+   :statuscode 200: no error
+   :statuscode 401: Authentication failure
+   :statuscode 403: The requested world/room does not exist **or** you have no permission to delete this resource.

--- a/docs/rest/resources/world.rst
+++ b/docs/rest/resources/world.rst
@@ -1,0 +1,115 @@
+World
+=====
+
+Resource description
+--------------------
+
+The world resource contains the following public fields:
+
+.. rst-class:: rest-resource-table
+
+===================================== ========================== =======================================================
+Field                                 Type                       Description
+===================================== ========================== =======================================================
+id                                    string                     The world's ID
+title                                 string                     A title for the world
+about                                 string                     A markdown-compatible description of the world for the
+                                                                 front page
+config                                object                     Various configuration properties
+permission_config                     object                     Permission rules mapping permission keys to lists of
+                                                                 traits
+domain                                string                     The FQDN of this world
+===================================== ========================== =======================================================
+
+Endpoints
+---------
+
+.. http:get:: /api/v1/worlds/(world_id)/
+
+   Returns the representation of the selected world.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /api/v1/worlds/sample/ HTTP/1.1
+      Accept: application/json, text/javascript
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "id": "sample",
+        "title": "Unsere tolle Online-Konferenz",
+        "about": "# Unsere tolle Online-Konferenz\n\nHallo!\nDas ist ein Markdowntext!",
+        "config": {},
+        "permission_config": {
+            "world.update": ["admin"],
+            "world.secrets": ["admin", "api"],
+            "world.announce": ["admin"],
+            "world.api": ["admin", "api"],
+            "room.create": ["admin"],
+            "room.announce": ["admin"],
+            "room.update": ["admin"],
+            "room.delete": ["admin"],
+            "chat.moderate": ["admin"],
+        },
+        "domain": "sample.venueless.events"
+      }
+
+   :statuscode 200: no error
+   :statuscode 401: Authentication failure
+   :statuscode 403: The world does not exist **or** you have no permission to view it.
+
+.. http:patch:: /api/v1/worlds/(world_id)/
+
+   Updates a world
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      PATCH /api/v1/worlds/sample/ HTTP/1.1
+      Accept: application/json, text/javascript
+      Content-Type: application/json
+
+      {
+        "title": "Happy World"
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: application/json
+
+      {
+        "id": "sample",
+        "title": "Happy World",
+        "about": "# Unsere tolle Online-Konferenz\n\nHallo!\nDas ist ein Markdowntext!",
+        "config": {},
+        "permission_config": {
+            "world.update": ["admin"],
+            "world.secrets": ["admin", "api"],
+            "world.announce": ["admin"],
+            "world.api": ["admin", "api"],
+            "room.create": ["admin"],
+            "room.announce": ["admin"],
+            "room.update": ["admin"],
+            "room.delete": ["admin"],
+            "chat.moderate": ["admin"],
+        },
+        "domain": "sample.venueless.events"
+      }
+
+   :statuscode 200: no error
+   :statuscode 400: The world could not be updated due to invalid submitted data.
+   :statuscode 401: Authentication failure
+   :statuscode 403: The requested organizer/event does not exist **or** you have no permission to create this resource.

--- a/server/sample/worlds/sample.json
+++ b/server/sample/worlds/sample.json
@@ -24,10 +24,13 @@
     ]
   },
   "permissions": {
+    "world.api": ["admin", "api"],
+    "world.secrets": ["admin", "api"],
     "world.update": ["admin"],
     "world.announce": ["admin"],
     "room.create": ["admin"],
     "room.announce": ["admin"],
+    "room.inspect": ["admin"],
     "room.update": ["admin"],
     "room.delete": ["admin"],
     "chat.moderate": ["admin"]

--- a/server/sample/worlds/sample.json
+++ b/server/sample/worlds/sample.json
@@ -30,7 +30,6 @@
     "world.announce": ["admin"],
     "room.create": ["admin"],
     "room.announce": ["admin"],
-    "room.inspect": ["admin"],
     "room.update": ["admin"],
     "room.delete": ["admin"],
     "chat.moderate": ["admin"]

--- a/server/tests/api/conftest.py
+++ b/server/tests/api/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client():
+    return APIClient()

--- a/server/tests/api/test_auth.py
+++ b/server/tests/api/test_auth.py
@@ -1,0 +1,119 @@
+import datetime
+
+import jwt
+import pytest
+
+
+@pytest.mark.django_db
+def test_no_auth_header(client):
+    r = client.get("/api/v1/worlds/sample/rooms/")
+    assert r.status_code == 403
+    assert r.data["detail"] == "Authentication credentials were not provided."
+
+
+@pytest.mark.django_db
+def test_invalid_token_header(client, world):
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer")
+    assert r.status_code == 403
+    assert r.data["detail"] == "Invalid token header. No credentials provided."
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer foo bar")
+    assert r.status_code == 403
+    assert (
+        r.data["detail"]
+        == "Invalid token header. Token string should not contain spaces."
+    )
+    r = client.get(
+        "/api/v1/worlds/sample/rooms/",
+        HTTP_AUTHORIZATION=b"Bearer F\xc3\xb8\xc3\xb6\xbbB\xc3\xa5r",
+    )
+    assert r.status_code == 403
+    assert (
+        r.data["detail"]
+        == "Invalid token header. Token string should not contain invalid characters."
+    )
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION=b"Bearer F")
+    assert r.status_code == 403
+    assert r.data["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+def test_non_existing_world(client):
+    r = client.get("/api/v1/worlds/bogus/rooms/", HTTP_AUTHORIZATION="Bearer Foobar")
+    assert r.status_code == 404
+
+
+@pytest.mark.django_db
+def test_invalid_token(client, world):
+    config = world.config["JWT_secrets"][0]
+    iat = datetime.datetime.utcnow()
+    exp = iat + datetime.timedelta(days=999)
+    payload = {
+        "iss": config["issuer"],
+        "aud": config["audience"],
+        "exp": exp,
+        "iat": iat,
+        "uid": 123456,
+        "traits": ["chat.read", "foo.bar"],
+    }
+    token = jwt.encode(payload, config["secret"] + "aaaa", algorithm="HS256").decode(
+        "utf-8"
+    )
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer " + token)
+    assert r.status_code == 403
+    assert r.data["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+def test_expired_token(client, world):
+    config = world.config["JWT_secrets"][0]
+    iat = datetime.datetime.utcnow()
+    exp = iat - datetime.timedelta(days=999)
+    payload = {
+        "iss": config["issuer"],
+        "aud": config["audience"],
+        "exp": exp,
+        "iat": iat,
+        "uid": 123456,
+        "traits": ["chat.read", "foo.bar"],
+    }
+    token = jwt.encode(payload, config["secret"], algorithm="HS256").decode("utf-8")
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer " + token)
+    assert r.status_code == 403
+    assert r.data["detail"] == "Invalid token."
+
+
+@pytest.mark.django_db
+def test_no_admin_token(client, world):
+    config = world.config["JWT_secrets"][0]
+    iat = datetime.datetime.utcnow()
+    exp = iat + datetime.timedelta(days=999)
+    payload = {
+        "iss": config["issuer"],
+        "aud": config["audience"],
+        "exp": exp,
+        "iat": iat,
+        "uid": 123456,
+        "traits": ["chat.read", "foo.bar"],
+    }
+    token = jwt.encode(payload, config["secret"], algorithm="HS256").decode("utf-8")
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer " + token)
+    assert r.status_code == 403
+    assert r.data["detail"] == "You do not have permission to perform this action."
+
+
+@pytest.mark.django_db
+def test_admin_token(client, world):
+    config = world.config["JWT_secrets"][0]
+    iat = datetime.datetime.utcnow()
+    exp = iat + datetime.timedelta(days=999)
+    payload = {
+        "iss": config["issuer"],
+        "aud": config["audience"],
+        "exp": exp,
+        "iat": iat,
+        "uid": 123456,
+        "traits": ["admin", "api", "chat.read", "foo.bar"],
+    }
+    token = jwt.encode(payload, config["secret"], algorithm="HS256").decode("utf-8")
+    r = client.get("/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION="Bearer " + token)
+    assert r.status_code == 200

--- a/server/tests/api/test_rooms.py
+++ b/server/tests/api/test_rooms.py
@@ -1,0 +1,109 @@
+import pytest
+from tests.api.utils import get_token_header
+
+
+@pytest.mark.django_db
+def test_room_list(client, world):
+    r = client.get(
+        "/api/v1/worlds/sample/rooms/", HTTP_AUTHORIZATION=get_token_header(world)
+    )
+    assert r.status_code == 200
+    assert r.data["count"] == 4
+    assert r.data["results"][0] == {
+        "id": str(world.rooms.first().id),
+        "permission_config": {},
+        "module_config": [
+            {
+                "type": "livestream.native",
+                "config": {"hls_url": "https://s1.live.pretix.eu/hls/sample.m3u8"},
+            },
+            {"type": "chat.native", "config": {"volatile": True}},
+        ],
+        "name": "Plenum",
+        "description": "Hier findet die Eröffnungs- und End-Veranstaltung statt",
+        "sorting_priority": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_room_detail(client, world):
+    r = client.get(
+        "/api/v1/worlds/sample/rooms/{}/".format(str(world.rooms.first().id)),
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 200
+    assert r.data == {
+        "id": str(world.rooms.first().id),
+        "permission_config": {},
+        "module_config": [
+            {
+                "type": "livestream.native",
+                "config": {"hls_url": "https://s1.live.pretix.eu/hls/sample.m3u8"},
+            },
+            {"type": "chat.native", "config": {"volatile": True}},
+        ],
+        "name": "Plenum",
+        "description": "Hier findet die Eröffnungs- und End-Veranstaltung statt",
+        "sorting_priority": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_room_delete(client, world):
+    world.permission_config["room.delete"] = ["foobartrait"]
+    world.save()
+    rid = world.rooms.first().id
+
+    r = client.delete(
+        "/api/v1/worlds/sample/rooms/{}/".format(str(rid)),
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 403
+    r = client.delete(
+        "/api/v1/worlds/sample/rooms/{}/".format(str(rid)),
+        HTTP_AUTHORIZATION=get_token_header(world, ["admin", "api", "foobartrait"]),
+    )
+    assert r.status_code == 204
+    assert not world.rooms.filter(id=rid).exists()
+
+
+@pytest.mark.django_db
+def test_room_update(client, world):
+    world.permission_config["room.update"] = ["foobartrait"]
+    world.save()
+    rid = world.rooms.first().id
+
+    r = client.patch(
+        "/api/v1/worlds/sample/rooms/{}/".format(str(rid)),
+        {"name": "Forum"},
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 403
+    r = client.patch(
+        "/api/v1/worlds/sample/rooms/{}/".format(str(rid)),
+        {"name": "Forum",},
+        HTTP_AUTHORIZATION=get_token_header(world, ["admin", "api", "foobartrait"]),
+    )
+    assert r.status_code == 200
+    assert world.rooms.get(id=rid).name == "Forum"
+
+
+@pytest.mark.django_db
+def test_room_create(client, world):
+    world.permission_config["room.create"] = ["foobartrait"]
+    world.save()
+
+    r = client.post(
+        "/api/v1/worlds/sample/rooms/",
+        {"name": "Forum", "sorting_priority": 100,},
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 403
+    r = client.post(
+        "/api/v1/worlds/sample/rooms/",
+        {"name": "Forum", "sorting_priority": 100,},
+        HTTP_AUTHORIZATION=get_token_header(world, ["admin", "api", "foobartrait"]),
+    )
+    assert r.status_code == 201
+    assert world.rooms.last().name == "Forum"
+    assert str(world.rooms.last().id) == r.data["id"]

--- a/server/tests/api/test_world.py
+++ b/server/tests/api/test_world.py
@@ -1,0 +1,61 @@
+import pytest
+from tests.api.utils import get_token_header
+
+
+@pytest.mark.django_db
+def test_world_config(client, world):
+    r = client.get("/api/v1/worlds/sample/", HTTP_AUTHORIZATION=get_token_header(world))
+    assert r.status_code == 200
+    assert r.data == {
+        "id": "sample",
+        "title": "Unsere tolle Online-Konferenz",
+        "about": "# Unsere tolle Online-Konferenz\n\nHallo!\nDas ist ein Markdowntext!",
+        "config": world.config,
+        "permission_config": world.permission_config,
+        "domain": None,
+    }
+
+
+@pytest.mark.django_db
+def test_world_config_protect_secrets(client, world):
+    world.permission_config["world.secrets"] = ["foobartrait"]
+    world.save()
+    r = client.get("/api/v1/worlds/sample/", HTTP_AUTHORIZATION=get_token_header(world))
+    assert r.status_code == 403
+    r = client.get(
+        "/api/v1/worlds/sample/",
+        HTTP_AUTHORIZATION=get_token_header(world, ["api", "foobartrait", "admin"]),
+    )
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_world_update(client, world):
+    world.permission_config["world.update"] = ["foobartrait"]
+    world.save()
+
+    r = client.patch(
+        "/api/v1/worlds/sample/",
+        {"title": "Democon"},
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 403
+
+    r = client.patch(
+        "/api/v1/worlds/sample/",
+        {"title": "Democon"},
+        HTTP_AUTHORIZATION=get_token_header(world, ["foobartrait", "admin", "api"]),
+    )
+    assert r.status_code == 200
+    world.refresh_from_db()
+    assert world.title == "Democon"
+
+
+@pytest.mark.django_db
+def test_world_no_delete(client, world):
+    r = client.delete(
+        "/api/v1/worlds/sample/",
+        {"title": "Democon"},
+        HTTP_AUTHORIZATION=get_token_header(world),
+    )
+    assert r.status_code == 403

--- a/server/tests/api/utils.py
+++ b/server/tests/api/utils.py
@@ -1,0 +1,20 @@
+import datetime
+
+import jwt
+
+
+def get_token_header(world, traits=["admin", "api"]):
+    config = world.config["JWT_secrets"][0]
+
+    iat = datetime.datetime.utcnow()
+    exp = iat + datetime.timedelta(days=999)
+    payload = {
+        "iss": config["issuer"],
+        "aud": config["audience"],
+        "exp": exp,
+        "iat": iat,
+        "uid": 123456,
+        "traits": traits,
+    }
+    token = jwt.encode(payload, config["secret"], algorithm="HS256").decode("utf-8")
+    return "Bearer " + token

--- a/server/venueless/api/__init__.py
+++ b/server/venueless/api/__init__.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    name = "venueless.api"
+    label = "api"

--- a/server/venueless/api/auth.py
+++ b/server/venueless/api/auth.py
@@ -4,7 +4,6 @@ from rest_framework.authentication import get_authorization_header
 
 from venueless.core.models import Room, World
 from venueless.core.services.world import has_permission
-from venueless.core.utils.jwt import _decode_token
 
 
 class WorldTokenAuthentication(authentication.BaseAuthentication):
@@ -41,7 +40,7 @@ class WorldTokenAuthentication(authentication.BaseAuthentication):
 
     def authenticate_credentials(self, key, world):
         try:
-            token = _decode_token(key, world)
+            token = world.decode_token(key)
             if not token:
                 raise exceptions.AuthenticationFailed("Invalid token.")
         except:

--- a/server/venueless/api/auth.py
+++ b/server/venueless/api/auth.py
@@ -2,7 +2,8 @@ from django.shortcuts import get_object_or_404
 from rest_framework import authentication, exceptions, permissions
 from rest_framework.authentication import get_authorization_header
 
-from venueless.core.models import World
+from venueless.core.models import Room, World
+from venueless.core.services.world import has_permission
 from venueless.core.utils.jwt import _decode_token
 
 
@@ -10,8 +11,8 @@ class WorldTokenAuthentication(authentication.BaseAuthentication):
     keyword = "Bearer"
 
     """
-    Authentification works exactly like the frontend, but since the REST API currently does not allow any operations
-    for which the logged-in user is relevant, we do not persist the user to the database but only keep the traits
+    Authentification works like the frontend, but since the REST API currently does not allow any operations for
+    which the logged-in user is relevant, we do not persist the user to the database but only keep the traits
     in the current request.
     """
 
@@ -23,7 +24,7 @@ class WorldTokenAuthentication(authentication.BaseAuthentication):
 
         if len(auth) == 1:
             msg = "Invalid token header. No credentials provided."
-            raise exceptions.AuthenticationFailed(msg)
+            raise exceptions.NotAuthenticated(msg)
         elif len(auth) > 2:
             msg = "Invalid token header. Token string should not contain spaces."
             raise exceptions.AuthenticationFailed(msg)
@@ -34,21 +35,78 @@ class WorldTokenAuthentication(authentication.BaseAuthentication):
             msg = "Invalid token header. Token string should not contain invalid characters."
             raise exceptions.AuthenticationFailed(msg)
 
-        world_id = request.kwargs["world_id"]
+        world_id = request.resolver_match.kwargs["world_id"]
         request.world = get_object_or_404(World, id=world_id)
         return self.authenticate_credentials(token, request.world)
 
     def authenticate_credentials(self, key, world):
-        token = _decode_token(key, world)
-        if not token:
+        try:
+            token = _decode_token(key, world)
+            if not token:
+                raise exceptions.AuthenticationFailed("Invalid token.")
+        except:
             raise exceptions.AuthenticationFailed("Invalid token.")
 
         return token.get("uid"), token
 
 
 class NoPermission(permissions.BasePermission):
-    def has_permission(self, request, view):
+    def has_permission(self, request, view):  # pragma: no cover
         return False
+
+
+class ApiAccessRequiredPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if isinstance(request.user, AnonymousUser):
+            return False
+        permset = request.world.permission_config
+        perm_key = "world.api"
+        return perm_key in permset and has_permission(
+            permset[perm_key], request.auth.get("traits")
+        )
+
+
+class WorldPermissions(permissions.BasePermission):
+    def has_permission(self, request, view):
+        permset = request.world.permission_config
+        if not has_permission(permset["world.secrets"], request.auth.get("traits")):
+            return False
+        if request.method in ("PATCH", "PUT"):
+            perm_key = "world.update"
+            return perm_key in permset and has_permission(
+                permset[perm_key], request.auth.get("traits")
+            )
+        elif request.method in ("HEAD", "GET", "OPTIONS"):
+            return True
+        return False
+
+
+class RoomPermissions(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method == "POST":
+            permset = request.world.permission_config
+            perm_key = "room.create"
+            return perm_key in permset and has_permission(
+                permset[perm_key], request.auth.get("traits")
+            )
+        else:
+            return True
+
+    def has_object_permission(self, request, view, obj: Room):
+        permset = request.world.permission_config
+        permset.update(obj.permission_config)
+
+        perm_key = None
+        if request.method in ("PATCH", "PUT"):
+            perm_key = "room.update"
+        elif request.method == "DELETE":
+            perm_key = "room.delete"
+        if perm_key:
+            return perm_key in permset and has_permission(
+                permset[perm_key], request.auth.get("traits")
+            )
+        else:
+            return True
 
 
 class AnonymousUser:

--- a/server/venueless/api/auth.py
+++ b/server/venueless/api/auth.py
@@ -1,0 +1,55 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import authentication, exceptions, permissions
+from rest_framework.authentication import get_authorization_header
+
+from venueless.core.models import World
+from venueless.core.utils.jwt import _decode_token
+
+
+class WorldTokenAuthentication(authentication.BaseAuthentication):
+    keyword = "Bearer"
+
+    """
+    Authentification works exactly like the frontend, but since the REST API currently does not allow any operations
+    for which the logged-in user is relevant, we do not persist the user to the database but only keep the traits
+    in the current request.
+    """
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            return None
+
+        if len(auth) == 1:
+            msg = "Invalid token header. No credentials provided."
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = "Invalid token header. Token string should not contain spaces."
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            token = auth[1].decode()
+        except UnicodeError:
+            msg = "Invalid token header. Token string should not contain invalid characters."
+            raise exceptions.AuthenticationFailed(msg)
+
+        world_id = request.kwargs["world_id"]
+        request.world = get_object_or_404(World, id=world_id)
+        return self.authenticate_credentials(token, request.world)
+
+    def authenticate_credentials(self, key, world):
+        token = _decode_token(key, world)
+        if not token:
+            raise exceptions.AuthenticationFailed("Invalid token.")
+
+        return token.get("uid"), token
+
+
+class NoPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return False
+
+
+class AnonymousUser:
+    pass

--- a/server/venueless/api/serializers.py
+++ b/server/venueless/api/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+from ..core.models import Room
+
+
+class RoomSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Room
+        fields = [
+            "id",
+            "permission_config",
+            "module_config",
+            "name",
+            "description",
+            "sorting_priority"
+            # TODO: picture
+        ]

--- a/server/venueless/api/serializers.py
+++ b/server/venueless/api/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from venueless.core.models import World
+
 from ..core.models import Room
 
 
@@ -14,4 +16,17 @@ class RoomSerializer(serializers.ModelSerializer):
             "description",
             "sorting_priority"
             # TODO: picture
+        ]
+
+
+class WorldSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = World
+        fields = [
+            "id",
+            "title",
+            "about",
+            "config",
+            "permission_config",
+            "domain",
         ]

--- a/server/venueless/api/serializers.py
+++ b/server/venueless/api/serializers.py
@@ -6,6 +6,11 @@ from ..core.models import Room
 
 
 class RoomSerializer(serializers.ModelSerializer):
+    module_config = serializers.ListField(
+        child=serializers.DictField(), required=False, default=[]
+    )
+    permission_config = serializers.DictField(required=False, default={})
+
     class Meta:
         model = Room
         fields = [
@@ -20,6 +25,9 @@ class RoomSerializer(serializers.ModelSerializer):
 
 
 class WorldSerializer(serializers.ModelSerializer):
+    config = serializers.DictField()
+    permission_config = serializers.DictField()
+
     class Meta:
         model = World
         fields = [

--- a/server/venueless/api/urls.py
+++ b/server/venueless/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, re_path
 from rest_framework import routers
 
 from . import views
@@ -7,5 +7,6 @@ world_router = routers.DefaultRouter()
 world_router.register(r"rooms", views.RoomViewSet)
 
 urlpatterns = [
-    path("worlds/<world_id>/", include(world_router.urls)),
+    re_path("worlds/(?P<world_id>[^/]+)/$", views.WorldView.as_view()),
+    re_path("worlds/(?P<world_id>[^/]+)/", include(world_router.urls)),
 ]

--- a/server/venueless/api/urls.py
+++ b/server/venueless/api/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework import routers
+
+from . import views
+
+world_router = routers.DefaultRouter()
+world_router.register(r"rooms", views.RoomViewSet)
+
+urlpatterns = [
+    path("worlds/<world_id>/", include(world_router.urls)),
+]

--- a/server/venueless/api/views.py
+++ b/server/venueless/api/views.py
@@ -1,6 +1,13 @@
 from rest_framework import viewsets
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from venueless.api.serializers import RoomSerializer
+from venueless.api.auth import (
+    ApiAccessRequiredPermission,
+    RoomPermissions,
+    WorldPermissions,
+)
+from venueless.api.serializers import RoomSerializer, WorldSerializer
 
 from ..core.models import Room
 
@@ -8,6 +15,24 @@ from ..core.models import Room
 class RoomViewSet(viewsets.ModelViewSet):
     queryset = Room.objects.none()
     serializer_class = RoomSerializer
+    permission_classes = [ApiAccessRequiredPermission & RoomPermissions]
 
     def get_queryset(self):
+        # TODO: Filter for rooms this user is allowed to see
         return self.request.world.rooms.all()
+
+    def perform_create(self, serializer):
+        serializer.save(world=self.request.world)
+
+
+class WorldView(APIView):
+    permission_classes = [ApiAccessRequiredPermission & WorldPermissions]
+
+    def get(self, request, **kwargs):
+        return Response(WorldSerializer(request.world).data)
+
+    def patch(self, request, **kwargs):
+        serializer = WorldSerializer(request.world, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)

--- a/server/venueless/api/views.py
+++ b/server/venueless/api/views.py
@@ -1,0 +1,13 @@
+from rest_framework import viewsets
+
+from venueless.api.serializers import RoomSerializer
+
+from ..core.models import Room
+
+
+class RoomViewSet(viewsets.ModelViewSet):
+    queryset = Room.objects.none()
+    serializer_class = RoomSerializer
+
+    def get_queryset(self):
+        return self.request.world.rooms.all()

--- a/server/venueless/api/views.py
+++ b/server/venueless/api/views.py
@@ -10,6 +10,7 @@ from venueless.api.auth import (
     WorldPermissions,
 )
 from venueless.api.serializers import RoomSerializer, WorldSerializer
+from venueless.core.models import Channel
 from venueless.core.services.world import notify_world_change
 
 from ..core.models import Room
@@ -26,18 +27,31 @@ class RoomViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(world=self.request.world)
+        for m in serializer.instance.module_config:
+            if m["type"] == "chat.native":
+                Channel.objects.get_or_create(
+                    room=serializer.instance, world=self.request.world
+                )
         transaction.on_commit(  # pragma: no cover
             lambda: async_to_sync(notify_world_change)(self.request.world.id)
         )
 
     def perform_update(self, serializer):
         super().perform_update(serializer)
+        for m in serializer.instance.module_config:
+            if m["type"] == "chat.native":
+                Channel.objects.get_or_create(
+                    room=serializer.instance, world=self.request.world
+                )
         transaction.on_commit(  # pragma: no cover
             lambda: async_to_sync(notify_world_change)(self.request.world.id)
         )
 
     def perform_destroy(self, instance):
         super().perform_destroy(instance)
+        for m in instance.module_config:
+            if m["type"] == "chat.native":
+                Channel.objects.filter(room=instance, world=self.request.world).delete()
         transaction.on_commit(  # pragma: no cover
             lambda: async_to_sync(notify_world_change)(self.request.world.id)
         )

--- a/server/venueless/core/models/chat.py
+++ b/server/venueless/core/models/chat.py
@@ -8,7 +8,7 @@ class Channel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     name = models.CharField(max_length=300, null=True)
     room = models.OneToOneField(
-        to="Room", related_name="channel", on_delete=models.PROTECT, null=True
+        to="Room", related_name="channel", on_delete=models.CASCADE, null=True
     )
     world = models.ForeignKey(
         to="World", related_name="channels", on_delete=models.CASCADE,

--- a/server/venueless/core/models/room.py
+++ b/server/venueless/core/models/room.py
@@ -4,13 +4,17 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 
 
+def empty_module_config():
+    return []
+
+
 class Room(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     world = models.ForeignKey(
         to="core.World", related_name="rooms", on_delete=models.PROTECT
     )
     permission_config = JSONField(null=True, blank=True)
-    module_config = JSONField(null=True, blank=True)
+    module_config = JSONField(null=True, default=empty_module_config)
     name = models.CharField(max_length=300)
     description = models.TextField(null=True, blank=True)
     picture = models.FileField(null=True, blank=True)

--- a/server/venueless/core/models/room.py
+++ b/server/venueless/core/models/room.py
@@ -18,4 +18,4 @@ class Room(models.Model):
     import_id = models.CharField(max_length=100, null=True, blank=True)
 
     class Meta:
-        ordering = ("import_id", "name")
+        ordering = ("sorting_priority", "name")

--- a/server/venueless/core/models/world.py
+++ b/server/venueless/core/models/world.py
@@ -29,12 +29,16 @@ class World(models.Model):
     permission_config = JSONField(null=True, blank=True, default=default_permissions)
     domain = models.CharField(max_length=250, unique=True, null=True, blank=True)
 
-    def decode_token(token):
+    def decode_token(self, token):
         for jwt_config in self.config["JWT_secrets"]:
             secret = jwt_config["secret"]
             audience = jwt_config["audience"]
             issuer = jwt_config["issuer"]
             with suppress(jwt.exceptions.InvalidSignatureError):
                 return jwt.decode(
-                    token, secret, algorithms=["HS256"], audience=audience, issuer=issuer
+                    token,
+                    secret,
+                    algorithms=["HS256"],
+                    audience=audience,
+                    issuer=issuer,
                 )

--- a/server/venueless/core/models/world.py
+++ b/server/venueless/core/models/world.py
@@ -1,3 +1,6 @@
+from contextlib import suppress
+
+import jwt
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 
@@ -5,7 +8,11 @@ from django.db import models
 def default_permissions():
     return {
         "world.update": ["admin"],
+        "world.secrets": ["admin", "api"],
         "world.announce": ["admin"],
+        # API is an additional permissions since it might always give read-access to secret stuff, e.g. in world or room
+        # configuration parameters
+        "world.api": ["admin", "api"],
         "room.create": ["admin"],
         "room.announce": ["admin"],
         "room.update": ["admin"],
@@ -21,3 +28,13 @@ class World(models.Model):
     config = JSONField(null=True, blank=True)
     permission_config = JSONField(null=True, blank=True, default=default_permissions)
     domain = models.CharField(max_length=250, unique=True, null=True, blank=True)
+
+    def decode_token(token):
+        for jwt_config in self.config["JWT_secrets"]:
+            secret = jwt_config["secret"]
+            audience = jwt_config["audience"]
+            issuer = jwt_config["issuer"]
+            with suppress(jwt.exceptions.InvalidSignatureError):
+                return jwt.decode(
+                    token, secret, algorithms=["HS256"], audience=audience, issuer=issuer
+                )

--- a/server/venueless/core/services/world.py
+++ b/server/venueless/core/services/world.py
@@ -43,6 +43,10 @@ def get_world_for_user(user):
     return user.world
 
 
+def has_permission(required_traits, given_traits):
+    return all(trait in given_traits for trait in required_traits)
+
+
 def get_permissions_for_traits(rules, traits, prefixes):
     return [
         permission

--- a/server/venueless/core/services/world.py
+++ b/server/venueless/core/services/world.py
@@ -2,6 +2,7 @@ import copy
 from contextlib import suppress
 
 from channels.db import database_sync_to_async
+from channels.layers import get_channel_layer
 from django.core.exceptions import ValidationError
 
 from venueless.core.models import Room, World
@@ -54,6 +55,10 @@ def get_permissions_for_traits(rules, traits, prefixes):
         if any(permission.startswith(prefix) for prefix in prefixes)
         and all(trait in traits for trait in required_traits)
     ]
+
+
+async def notify_world_change(world_id):
+    await get_channel_layer().group_send(f"world.{world_id}", {"type": "world.update",})
 
 
 async def get_world_config_for_user(user):

--- a/server/venueless/core/utils/jwt.py
+++ b/server/venueless/core/utils/jwt.py
@@ -5,8 +5,7 @@ import jwt
 from venueless.core.services.world import get_world
 
 
-async def decode_token(token, world_id):
-    world = await get_world(world_id)
+def _decode_token(token, world):
     for jwt_config in world.config["JWT_secrets"]:
         secret = jwt_config["secret"]
         audience = jwt_config["audience"]
@@ -15,3 +14,8 @@ async def decode_token(token, world_id):
             return jwt.decode(
                 token, secret, algorithms=["HS256"], audience=audience, issuer=issuer
             )
+
+
+async def decode_token(token, world_id):
+    world = await get_world(world_id)
+    return _decode_token(token, world)

--- a/server/venueless/core/utils/jwt.py
+++ b/server/venueless/core/utils/jwt.py
@@ -3,4 +3,4 @@ from venueless.core.services.world import get_world
 
 async def decode_token(token, world_id):
     world = await get_world(world_id)
-    return world.decode_token(token, world)
+    return world.decode_token(token)

--- a/server/venueless/core/utils/jwt.py
+++ b/server/venueless/core/utils/jwt.py
@@ -1,21 +1,6 @@
-from contextlib import suppress
-
-import jwt
-
 from venueless.core.services.world import get_world
-
-
-def _decode_token(token, world):
-    for jwt_config in world.config["JWT_secrets"]:
-        secret = jwt_config["secret"]
-        audience = jwt_config["audience"]
-        issuer = jwt_config["issuer"]
-        with suppress(jwt.exceptions.InvalidSignatureError):
-            return jwt.decode(
-                token, secret, algorithms=["HS256"], audience=audience, issuer=issuer
-            )
 
 
 async def decode_token(token, world_id):
     world = await get_world(world_id)
-    return _decode_token(token, world)
+    return world.decode_token(token, world)

--- a/server/venueless/live/consumers.py
+++ b/server/venueless/live/consumers.py
@@ -71,6 +71,8 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
         if message["type"] == "user.broadcast":
             if self.socket_id != message["socket"]:
                 await self.send_json([message["event_type"], message["data"]])
+        elif message["type"] == "world.update":
+            await self.components["user"].dispatch_event(self, message)
         elif message["type"].startswith("chat."):
             await self.components["chat"].dispatch_event(self, message)
         else:

--- a/server/venueless/live/modules/auth.py
+++ b/server/venueless/live/modules/auth.py
@@ -1,7 +1,5 @@
 import logging
 
-from channels.db import database_sync_to_async
-
 from venueless.core.serializers.auth import PublicUserSerializer
 from venueless.core.services.chat import ChatService
 from venueless.core.services.user import get_public_user, get_user, update_user
@@ -26,7 +24,6 @@ class AuthModule:
                 return
             user = await get_user(self.world, with_token=token, serialize=False)
         self.consumer.user = PublicUserSerializer().to_representation(user)
-        await database_sync_to_async(self.consumer.scope["session"].save)()
         await self.consumer.send_json(
             [
                 "authenticated",

--- a/server/venueless/live/modules/auth.py
+++ b/server/venueless/live/modules/auth.py
@@ -41,6 +41,9 @@ class AuthModule:
         await self.consumer.channel_layer.group_add(
             f"user.{self.consumer.user['id']}", self.consumer.channel_name
         )
+        await self.consumer.channel_layer.group_add(
+            f"world.{self.world}", self.consumer.channel_name
+        )
 
     async def update(self):
         new_data = await update_user(
@@ -77,4 +80,7 @@ class AuthModule:
         if self.consumer.user:
             await self.consumer.channel_layer.group_discard(
                 f"user.{self.consumer.user['id']}", self.consumer.channel_name
+            )
+            await self.consumer.channel_layer.group_discard(
+                f"world.{self.world}", self.consumer.channel_name
             )

--- a/server/venueless/live/modules/auth.py
+++ b/server/venueless/live/modules/auth.py
@@ -55,6 +55,14 @@ class AuthModule:
             "user.updated", await get_public_user(self.world, self.consumer.user["id"])
         )
 
+    async def push_world_update(self):
+        world_config = await get_world_config_for_user(
+            await get_user(
+                self.world, with_id=self.consumer.user["id"], serialize=False
+            )
+        )
+        await self.consumer.send_json(["world.updated", world_config])
+
     async def dispatch_command(self, consumer, content):
         self.consumer = consumer
         self.content = content
@@ -74,6 +82,18 @@ class AuthModule:
             await self.consumer.send_success(user)
         else:
             await self.consumer.send_error(code="user.not_found")
+
+    async def dispatch_event(self, consumer, content):
+        self.consumer = consumer
+        self.content = content
+        self.world = self.consumer.scope["url_route"]["kwargs"]["world"]
+        self.service = ChatService(self.world)
+        if self.content["type"] == "world.update":
+            await self.push_world_update()
+        else:  # pragma: no cover
+            logger.warning(
+                f'Ignored unknown event {content["type"]}'
+            )  # ignore unknown event
 
     async def dispatch_disconnect(self, consumer, close_code):
         self.consumer = consumer

--- a/server/venueless/settings.py
+++ b/server/venueless/settings.py
@@ -135,20 +135,12 @@ else:
     ALLOWED_HOSTS = [urlparse(SITE_URL).netloc]
 
 if os.getenv("VENUELESS_COOKIE_DOMAIN", ""):
-    # SESSION_COOKIE_DOMAIN = os.getenv("VENUELESS_COOKIE_DOMAIN", "")
     CSRF_COOKIE_DOMAIN = os.getenv("VENUELESS_COOKIE_DOMAIN", "")
 
-# SESSION_COOKIE_SECURE = (
-#     os.getenv("VENUELESS_HTTPS", "True" if SITE_URL.startswith("https:") else "False")
-#     == "True"
-# )
-
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
-# SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
-    # "django.contrib.sessions",
     "channels",
     "rest_framework",
     "venueless.core.CoreConfig",
@@ -166,7 +158,6 @@ except ImportError:
 MIDDLEWARE = [
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    # "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -226,9 +217,7 @@ LANGUAGES = [
 
 LOCALE_PATHS = (os.path.join(os.path.dirname(__file__), "locale"),)
 
-# SESSION_COOKIE_NAME = "venueless_session"
 CSRF_COOKIE_NAME = "venueless_csrftoken"
-SESSION_COOKIE_HTTPONLY = True
 
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 

--- a/server/venueless/settings.py
+++ b/server/venueless/settings.py
@@ -3,7 +3,6 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from django.contrib import messages
 from django.utils.crypto import get_random_string
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -136,22 +135,24 @@ else:
     ALLOWED_HOSTS = [urlparse(SITE_URL).netloc]
 
 if os.getenv("VENUELESS_COOKIE_DOMAIN", ""):
-    SESSION_COOKIE_DOMAIN = os.getenv("VENUELESS_COOKIE_DOMAIN", "")
+    # SESSION_COOKIE_DOMAIN = os.getenv("VENUELESS_COOKIE_DOMAIN", "")
     CSRF_COOKIE_DOMAIN = os.getenv("VENUELESS_COOKIE_DOMAIN", "")
 
-SESSION_COOKIE_SECURE = (
-    os.getenv("VENUELESS_HTTPS", "True" if SITE_URL.startswith("https:") else "False")
-    == "True"
-)
+# SESSION_COOKIE_SECURE = (
+#     os.getenv("VENUELESS_HTTPS", "True" if SITE_URL.startswith("https:") else "False")
+#     == "True"
+# )
 
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
+# SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
+    # "django.contrib.sessions",
     "channels",
+    "rest_framework",
     "venueless.core.CoreConfig",
+    "venueless.api.ApiConfig",
     "venueless.live.LiveConfig",
 ]
 
@@ -165,7 +166,7 @@ except ImportError:
 MIDDLEWARE = [
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
+    # "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -225,7 +226,7 @@ LANGUAGES = [
 
 LOCALE_PATHS = (os.path.join(os.path.dirname(__file__), "locale"),)
 
-SESSION_COOKIE_NAME = "venueless_session"
+# SESSION_COOKIE_NAME = "venueless_session"
 CSRF_COOKIE_NAME = "venueless_csrftoken"
 SESSION_COOKIE_HTTPONLY = True
 
@@ -236,15 +237,6 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 INTERNAL_IPS = ("127.0.0.1", "::1")
-
-MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
-
-MESSAGE_TAGS = {
-    messages.INFO: "alert-info",
-    messages.ERROR: "alert-danger",
-    messages.WARNING: "alert-warning",
-    messages.SUCCESS: "alert-success",
-}
 
 loglevel = "DEBUG" if DEBUG else "INFO"
 
@@ -290,15 +282,12 @@ LOGGING = {
 }
 
 REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": [
-        # TODO
-    ],
+    "DEFAULT_PERMISSION_CLASSES": ["venueless.api.auth.NoPermission",],
+    "UNAUTHENTICATED_USER": "venueless.api.auth.AnonymousUser",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "PAGE_SIZE": 50,
-    "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.SessionAuthentication",
-    ),
+    "DEFAULT_AUTHENTICATION_CLASSES": ("venueless.api.auth.WorldTokenAuthentication",),
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
     "UNICODE_JSON": False,
 }

--- a/server/venueless/urls.py
+++ b/server/venueless/urls.py
@@ -1,7 +1,9 @@
-from django.urls import re_path
+from django.urls import include, re_path
 
+from .api.urls import urlpatterns as api_patterns
 from .live import views
 
 urlpatterns = [
+    re_path(r"^api/v1/", include(api_patterns)),
     re_path(r"(.*)", views.AppView.as_view()),
 ]


### PR DESCRIPTION
This PR adds a RESTful API to manage world configuration and rooms. This is **not** intended to be used by the venueless webapp, I still think we should do as much websocket as possible there.

Instead, this is intended to be used by external systems like pretix or pretalx to automatically push over room configurations etc.

For simplicity, I opted to use the very same JWT configuration for authentication with a few extra permission flags, even though the API authentication currently does not persist users to the venueless database (no need to).

Any changes to the room or world config result in the world configuration to be pushed to all connected clients.

If you agree with the general design, I would add documentation as well.

TODO:

- [x] Auto-create channels whenever a chat module is added to a room
- [x] Docs