### PR TITLE
[webapp] Make sure BBB reloads when switching rooms

### DIFF
--- a/webapp/src/components/BigBlueButton.vue
+++ b/webapp/src/components/BigBlueButton.vue
@@ -23,21 +23,30 @@ export default {
 		}
 	},
 	computed: {},
-	async created () {
-		try {
-			const {url} = await api.call('bbb.url', {room: this.room.id})
-			this.url = url
-		} catch (error) {
-			// TODO handle bbb.join.missing_profile
-			this.error = error
-			console.log(error)
+	watch: {
+		async room () {
+			await this.start()
 		}
+	},
+	async created () {
+		await this.start()
 	},
 	mounted () {
 		this.$nextTick(() => {
 		})
 	},
-	methods: {}
+	methods: {
+		async start () {
+			try {
+				const {url} = await api.call('bbb.url', {room: this.room.id})
+				this.url = url
+			} catch (error) {
+				// TODO handle bbb.join.missing_profile
+				this.error = error
+				console.log(error)
+			}
+		}
+	}
 }
 </script>
 <style lang="stylus">


### PR DESCRIPTION
When you have multiple BBB rooms and try to switch between them, you stay in the same room currently. This is bad, and relatively urgent since it breaks a demo/test use case for next week, so I tried to fix it, but I know ``watch`` is usually not great design and am happy for pointers if there's a better implementation.