### PR TITLE
Allow OR statements in trait grants

### DIFF
--- a/docs/developer/api/permissions.rst
+++ b/docs/developer/api/permissions.rst
@@ -96,3 +96,8 @@ the configuration would look like this::
       "participant": ["pretix-product-1234", "pretix-product-5678"]
     }
 
+It's also possible to have "OR"-type grants::
+
+    "trait_grants": {
+      "participant": ["pretix-event-foo", ["pretix-product-1234", "pretix-product-5678"]]
+    }

--- a/server/tests/live/test_auth.py
+++ b/server/tests/live/test_auth.py
@@ -423,7 +423,9 @@ async def test_auth_with_jwt_token_and_permission_traits(world):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_auth_private_rooms_in_world_config(world, bbb_room, chat_room):
+async def test_auth_private_rooms_in_world_config(
+    world, bbb_room, chat_room, stream_room
+):
     config = world.config["JWT_secrets"][0]
     iat = datetime.datetime.utcnow()
     exp = iat + datetime.timedelta(days=999)
@@ -456,9 +458,13 @@ async def test_auth_private_rooms_in_world_config(world, bbb_room, chat_room):
         }
 
     chat_room.trait_grants = {
-        "participant": ["blablabla"],
+        "participant": [["unknowen", "blablabla"]],
     }
     await database_sync_to_async(chat_room.save)()
+    stream_room.trait_grants = {
+        "participant": ["blablabla"],
+    }
+    await database_sync_to_async(stream_room.save)()
 
     async with world_communicator() as c:
         await c.send_json_to(["authenticate", {"token": token}])

--- a/server/venueless/core/models/room.py
+++ b/server/venueless/core/models/room.py
@@ -3,6 +3,7 @@ import uuid
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db.models import Exists, OuterRef, Q
+from django.db.models.expressions import RawSQL
 from rest_framework import serializers
 
 from venueless.core.models.cache import VersionedModel
@@ -57,26 +58,66 @@ class RoomQuerySet(models.QuerySet):
             qs = self
             requirements = Q()
 
-        # Implicit role grants
-        for role in roles:
-            requirements |= Q(
-                Q(
+        # Implicit role grants, i.e. grants given by trait_grants values on the room itself
+        # We calculate this entirely in SQL for performance reasons. This is a little more complicated
+        # since trait_grants can contain AND and OR restrictions.
+        # For example, if we know from above the "moderator" role would grant the required permission, we need to
+        # check the trait_grants["moderator"] value of the room, which always is an array. All values inside the
+        # array are connected as AND restrictions. However, the value may either be strings (user must have that trait)
+        # or arrays (user must have one of the traits -- OR). We therefore need to do In-SQL type checks.
+        # In case it is an empty array, everyone is permitted. When our user has traits, this is automatically ensured
+        # by the ALL() statement, but when traits=[] we need to do a special case check since "IN ()" is not valid SQL
+        for i, role in enumerate(roles):
+            if traits:
+                qs = qs.annotate(
                     **{
-                        "trait_grants__has_key": role,
-                        f"trait_grants__{role}__contained_by": user.traits,
+                        f"has_role_{i}": RawSQL(
+                            f"""(
+                            trait_grants ? %s AND
+                            trait_grants->%s IS NOT NULL AND
+                            TRUE = ALL(
+                                SELECT (
+                                    CASE jsonb_typeof(d{i}.elem)
+                                        WHEN 'array' THEN EXISTS(SELECT 1 FROM jsonb_array_elements(d{i}.elem) e{i}(elem) WHERE e{i}.elem#>>'{"{}"}' IN %s )
+                                        ELSE d{i}.elem#>>'{"{}"}' IN %s
+                                    END
+                                ) FROM jsonb_array_elements( trait_grants->%s ) AS d{i}(elem)
+                            )
+                        )""",
+                            (
+                                role,  # ? check
+                                role,  # IS NOT NULL check
+                                tuple(traits),  # IN check
+                                tuple(traits),  # IN check
+                                role,  # jsonb_array_elements
+                            ),
+                        )
                     }
                 )
-                & ~Q(
+            else:
+                qs = qs.annotate(
                     **{
-                        f"trait_grants__{role}": None,
+                        f"has_role_{i}": RawSQL(
+                            f"""(
+                            trait_grants ? %s AND
+                            trait_grants->%s IS NOT NULL AND
+                            jsonb_array_length(trait_grants->%s) = 0
+                        )""",
+                            (
+                                role,  # ? check
+                                role,  # IS NOT NULL check
+                                role,  # jsonb_array_length
+                            ),
+                        )
                     }
                 )
-            )
+            requirements |= Q(**{f"has_role_{i}": True})
 
-        return qs.filter(
+        qs = qs.filter(
             requirements,
             world=world,
         )
+        return qs
 
 
 class Room(VersionedModel):

--- a/server/venueless/core/models/room.py
+++ b/server/venueless/core/models/room.py
@@ -98,11 +98,11 @@ class RoomQuerySet(models.QuerySet):
                 qs = qs.annotate(
                     **{
                         f"has_role_{i}": RawSQL(
-                            f"""(
-                            trait_grants ? %s AND
-                            trait_grants->%s IS NOT NULL AND
-                            jsonb_array_length(trait_grants->%s) = 0
-                        )""",
+                            """(
+                                trait_grants ? %s AND
+                                trait_grants->%s IS NOT NULL AND
+                                jsonb_array_length(trait_grants->%s) = 0
+                            )""",
                             (
                                 role,  # ? check
                                 role,  # IS NOT NULL check

--- a/server/venueless/core/models/world.py
+++ b/server/venueless/core/models/world.py
@@ -104,7 +104,8 @@ class World(VersionedModel):
     ):
         for role, required_traits in self.trait_grants.items():
             if isinstance(required_traits, list) and all(
-                r in traits for r in required_traits
+                any(x in traits for x in (r if isinstance(r, list) else [r]))
+                for r in required_traits
             ):
                 if any(p.value in self.roles.get(role, []) for p in permissions):
                     return True
@@ -112,7 +113,8 @@ class World(VersionedModel):
         if room:
             for role, required_traits in room.trait_grants.items():
                 if isinstance(required_traits, list) and all(
-                    r in traits for r in required_traits
+                    any(x in traits for x in (r if isinstance(r, list) else [r]))
+                    for r in required_traits
                 ):
                     if any(p.value in self.roles.get(role, []) for p in permissions):
                         return True
@@ -179,7 +181,8 @@ class World(VersionedModel):
 
         for role, required_traits in self.trait_grants.items():
             if isinstance(required_traits, list) and all(
-                r in user.traits for r in required_traits
+                any(x in user.traits for x in (r if isinstance(r, list) else [r]))
+                for r in required_traits
             ):
                 result[self].update(self.roles.get(role, []))
 
@@ -189,7 +192,8 @@ class World(VersionedModel):
         for room in self.rooms.all():
             for role, required_traits in room.trait_grants.items():
                 if isinstance(required_traits, list) and all(
-                    r in user.traits for r in required_traits
+                    any(x in user.traits for x in (r if isinstance(r, list) else [r]))
+                    for r in required_traits
                 ):
                     result[room].update(self.roles.get(role, []))
 

--- a/webapp/src/components/config/PermissionConfig.vue
+++ b/webapp/src/components/config/PermissionConfig.vue
@@ -58,7 +58,7 @@ export default {
 		set_trait_grants (role, traits) {
 			if (typeof this.config.trait_grants[role] !== 'undefined') {
 				this.$set(this.config.trait_grants, role, traits.split(',').map(
-					(i) => i.trim().split("|").filter((j) => j.length > 0)
+					(i) => i.trim().split('|').filter((j) => j.length > 0)
 				).filter((i) => i.length > 0))
 			}
 		},

--- a/webapp/src/components/config/PermissionConfig.vue
+++ b/webapp/src/components/config/PermissionConfig.vue
@@ -12,7 +12,7 @@
 										@input="toggle_trait_grants(key, $event)")
 			bunt-input(label="Required traits (comma-separated)", @input="set_trait_grants(key, $event)",
 									:disabled="typeof config.trait_grants[key] === 'undefined'", name="g"
-									:value="config.trait_grants[key] ? config.trait_grants[key].join(', ') : ''")
+									:value="config.trait_grants[key] ? config.trait_grants[key].map(i => (Array.isArray(i) ? i.join('|') : i)).join(', ') : ''")
 		bunt-button.btn-add-role(@click="add_role") Add new role
 		bunt-button.btn-save(@click="save", :loading="saving") Save
 
@@ -57,7 +57,9 @@ export default {
 		},
 		set_trait_grants (role, traits) {
 			if (typeof this.config.trait_grants[role] !== 'undefined') {
-				this.$set(this.config.trait_grants, role, traits.split(',').map((i) => i.trim()))
+				this.$set(this.config.trait_grants, role, traits.split(',').map(
+					(i) => i.trim().split("|").filter((j) => j.length > 0)
+				).filter((i) => i.length > 0))
 			}
 		},
 		add_role () {

--- a/webapp/src/views/admin/room.vue
+++ b/webapp/src/views/admin/room.vue
@@ -25,7 +25,7 @@
 							bunt-input(:value="key", label="Role name", @input="set_role_name(key, $event)", name="n", :disabled="index < Object.keys(config.trait_grants).length - 1")
 						td
 							bunt-input(label="Required traits (comma-separated)", @input="set_trait_grants(key, $event)", name="g"
-													:value="val ? val.join(', ') : ''")
+												:value="val ? val.map(i => (Array.isArray(i) ? i.join('|') : i)).join(', ') : ''")
 						td.actions
 							bunt-icon-button(@click="remove_role(key)") delete-outline
 				tfoot
@@ -154,7 +154,9 @@ export default {
 	methods: {
 		set_trait_grants (role, traits) {
 			if (typeof this.config.trait_grants[role] !== 'undefined') {
-				this.$set(this.config.trait_grants, role, traits.split(',').map((i) => i.trim()).filter((i) => i.length > 0))
+				this.$set(this.config.trait_grants, role, traits.split(',').map(
+					(i) => i.trim().split("|").filter((j) => j.length > 0)
+				).filter((i) => i.length > 0))
 			}
 		},
 		remove_role (role) {

--- a/webapp/src/views/admin/room.vue
+++ b/webapp/src/views/admin/room.vue
@@ -155,7 +155,7 @@ export default {
 		set_trait_grants (role, traits) {
 			if (typeof this.config.trait_grants[role] !== 'undefined') {
 				this.$set(this.config.trait_grants, role, traits.split(',').map(
-					(i) => i.trim().split("|").filter((j) => j.length > 0)
+					(i) => i.trim().split('|').filter((j) => j.length > 0)
 				).filter((i) => i.length > 0))
 			}
 		},


### PR DESCRIPTION
One of the biggest drawbacks of our permission system when configuring real-life events is that I currently can't say "this room may be entered with trait A **or** B", but instead need to set up different roles. One recent event had redundant roles like "viewer1", "viewer2", "viewer3", … which is really annoying and leads to mistakes. This PR attempts to fix this by a simple extension of the data structure and some dark magic SQL.