### PR TITLE
Chat: allow to send pictures and other files

### DIFF
--- a/docs/developer/api/chat.rst
+++ b/docs/developer/api/chat.rst
@@ -171,7 +171,8 @@ inside the ``content`` property:
 Currently, the following types are defined:
 
 * ``text``: A plain text message. ``body`` is a string with the message.
-* ``image``: A message containing an image. ``src`` is the URL of the image.
+* ``files``: A message containing one or multiple files. ``files`` contains a list of files, each with an ``url`` and a
+  ``mimeType``. Additionally, an optional ``body`` text can also be given.
 * ``deleted``: Any message that was removed by the user or a moderator.
 * ``call``: A audio/video call that can be joined. ``body`` is a dictionary that should be empty when you send such a
   message. If you receive such a message, there will be an ``id`` property with the call ID which you can use to fetch

--- a/docs/developer/api/chat.rst
+++ b/docs/developer/api/chat.rst
@@ -171,7 +171,7 @@ inside the ``content`` property:
 Currently, the following types are defined:
 
 * ``text``: A plain text message. ``body`` is a string with the message.
-* ``image``: An image containing an image. ``src`` is the URL of the image.
+* ``image``: A message containing an image. ``src`` is the URL of the image.
 * ``deleted``: Any message that was removed by the user or a moderator.
 * ``call``: A audio/video call that can be joined. ``body`` is a dictionary that should be empty when you send such a
   message. If you receive such a message, there will be an ``id`` property with the call ID which you can use to fetch

--- a/docs/developer/api/chat.rst
+++ b/docs/developer/api/chat.rst
@@ -171,6 +171,7 @@ inside the ``content`` property:
 Currently, the following types are defined:
 
 * ``text``: A plain text message. ``body`` is a string with the message.
+* ``image``: An image containing an image. ``src`` is the URL of the image.
 * ``deleted``: Any message that was removed by the user or a moderator.
 * ``call``: A audio/video call that can be joined. ``body`` is a dictionary that should be empty when you send such a
   message. If you receive such a message, there will be an ``id`` property with the call ID which you can use to fetch

--- a/docs/developer/api/chat.rst
+++ b/docs/developer/api/chat.rst
@@ -171,8 +171,8 @@ inside the ``content`` property:
 Currently, the following types are defined:
 
 * ``text``: A plain text message. ``body`` is a string with the message.
-* ``files``: A message containing one or multiple files. ``files`` contains a list of files, each with an ``url`` and a
-  ``mimeType``. Additionally, an optional ``body`` text can also be given.
+* ``files``: A message containing one or multiple files. ``files`` contains a list of files, each with an ``url``, a
+  ``name``, and a ``mimeType``. Additionally, an optional ``body`` text can be given.
 * ``deleted``: Any message that was removed by the user or a moderator.
 * ``call``: A audio/video call that can be joined. ``body`` is a dictionary that should be empty when you send such a
   message. If you receive such a message, there will be an ``id`` property with the call ID which you can use to fetch

--- a/server/venueless/live/modules/chat.py
+++ b/server/venueless/live/modules/chat.py
@@ -329,6 +329,7 @@ class ChatModule(BaseModule):
             raise ConsumerException("chat.unsupported_event_type")
         if not (
             content.get("type") == "text"
+            or content.get("type") == "image"
             or (content.get("type") == "deleted" and "replaces" in body)
             or (content.get("type") == "call" and not self.channel.room)
         ):
@@ -357,6 +358,9 @@ class ChatModule(BaseModule):
             )
 
         if content.get("type") == "text" and not content.get("body"):
+            raise ConsumerException("chat.empty")
+
+        if content.get("type") == "image" and not content.get("src"):
             raise ConsumerException("chat.empty")
 
         if await self.consumer.user.is_blocked_in_channel_async(self.channel):

--- a/server/venueless/live/modules/chat.py
+++ b/server/venueless/live/modules/chat.py
@@ -329,7 +329,7 @@ class ChatModule(BaseModule):
             raise ConsumerException("chat.unsupported_event_type")
         if not (
             content.get("type") == "text"
-            or content.get("type") == "image"
+            or content.get("type") == "files"
             or (content.get("type") == "deleted" and "replaces" in body)
             or (content.get("type") == "call" and not self.channel.room)
         ):
@@ -360,7 +360,7 @@ class ChatModule(BaseModule):
         if content.get("type") == "text" and not content.get("body"):
             raise ConsumerException("chat.empty")
 
-        if content.get("type") == "image" and not content.get("src"):
+        if content.get("type") == "files" and not content.get("files"):
             raise ConsumerException("chat.empty")
 
         if await self.consumer.user.is_blocked_in_channel_async(self.channel):

--- a/webapp/src/components/Chat.vue
+++ b/webapp/src/components/Chat.vue
@@ -125,7 +125,7 @@ export default {
 			this.$store.dispatch('chat/sendMessage', {text: message})
 		},
 		sendFiles (files, message) {
-			this.$store.dispatch('chat/sendFiles', files, message)
+			this.$store.dispatch('chat/sendFiles', {files: files, message: message})
 		},
 		async showUserCard (event, user) {
 			this.selectedUser = user

--- a/webapp/src/components/Chat.vue
+++ b/webapp/src/components/Chat.vue
@@ -11,7 +11,7 @@
 				.no-permission(v-if="room && !room.permissions.includes('room:chat.join')") {{ $t('Chat:permission-block:room:chat.join') }}
 				bunt-button(v-else-if="!activeJoinedChannel", @click="join", :tooltip="$t('Chat:join-button:tooltip')") {{ $t('Chat:join-button:label') }}
 				.no-permission(v-else-if="room && !room.permissions.includes('room:chat.send')") {{ $t('Chat:permission-block:room:chat.send') }}
-				chat-input(v-else, @send="send", @sendImage="sendImage")
+				chat-input(v-else, @send="send", @sendFiles="sendFiles")
 		.user-list(v-if="mode === 'standalone' && showUserlist && $mq.above['m']")
 			.user-list-info(v-if="sortedMembers.length > 2")
 				span Channel members
@@ -124,8 +124,8 @@ export default {
 		send (message) {
 			this.$store.dispatch('chat/sendMessage', {text: message})
 		},
-		sendImage (url) {
-			this.$store.dispatch('chat/sendImage', {src: url})
+		sendFiles (files, message) {
+			this.$store.dispatch('chat/sendFiles', files, message)
 		},
 		async showUserCard (event, user) {
 			this.selectedUser = user

--- a/webapp/src/components/Chat.vue
+++ b/webapp/src/components/Chat.vue
@@ -11,7 +11,7 @@
 				.no-permission(v-if="room && !room.permissions.includes('room:chat.join')") {{ $t('Chat:permission-block:room:chat.join') }}
 				bunt-button(v-else-if="!activeJoinedChannel", @click="join", :tooltip="$t('Chat:join-button:tooltip')") {{ $t('Chat:join-button:label') }}
 				.no-permission(v-else-if="room && !room.permissions.includes('room:chat.send')") {{ $t('Chat:permission-block:room:chat.send') }}
-				chat-input(v-else, @send="send")
+				chat-input(v-else, @send="send", @sendImage="sendImage")
 		.user-list(v-if="mode === 'standalone' && showUserlist && $mq.above['m']")
 			.user-list-info(v-if="sortedMembers.length > 2")
 				span Channel members
@@ -123,6 +123,9 @@ export default {
 		},
 		send (message) {
 			this.$store.dispatch('chat/sendMessage', {text: message})
+		},
+		sendImage (url) {
+			this.$store.dispatch('chat/sendImage', {src: url})
 		},
 		async showUserCard (event, user) {
 			this.selectedUser = user

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -14,6 +14,7 @@ bunt-input-outline-container.c-chat-input
 			a.chat-file(v-else :href="file.url" target="_blank")
 				i.bunt-icon.mdi.mdi-file
 				| {{ file.name }}
+		bunt-icon-button#btn-remove-attachment(@click="files = null") close-circle
 	bunt-icon-button#btn-send(@click="send") send
 </template>
 <script>
@@ -227,6 +228,13 @@ export default {
 			font-size: 18px
 			height: 24px
 			line-height: @height
+	#btn-remove-attachment
+		position: absolute
+		right: -14px
+		top: -14px
+		icon-button-style(color: $clr-secondary-text-light)
+		height: 28px
+		width: 28px
 	.files-preview
 		position:absolute
 		top: 0;

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -8,8 +8,8 @@ bunt-input-outline-container.c-chat-input
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
 	upload-button#btn-file(@change="attachFiles", accept="image/png, image/jpg, application/pdf, .png, .jpg, .jpeg, .pdf", icon="paperclip", multiple=true)
-	.files-preview
-		.file-message-part(v-for="file in files")
+	.files-preview(v-if="files !== null")
+		template(v-for="file in files")
 			img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
 			a.chat-file(v-else :href="file.url")
 				i.bunt-icon.mdi.mdi-file
@@ -230,9 +230,34 @@ export default {
 	.files-preview
 		position:absolute
 		top: 0;
+		left: 28px
+		right: 8px
+		border-radius 4px 4px 0 0
+		box-sizing: border-box
 		transform: translateY(-100%)
-		background #d9d9d9
+		background white
+		border: 1px solid $clr-grey-400
+		border-bottom: none
+		padding: 8px
 		.chat-image
-			max-width: 50%
-			max-height: 100px
+			display: inline-block
+			width: 60px
+			height: 60px
+			object-fit: cover
+			box-sizing: border-box
+			border-radius 2px
+			border: 1px solid $clr-grey-400
+			margin: 0 4px
+		.chat-file
+			display: inline-block
+			height: 60px
+			max-width: 100px
+			border-radius 2px
+			border: 1px solid $clr-grey-400
+			text-overflow: ellipsis
+			overflow: hidden
+			white-space: nowrap
+			padding: 12px 8px
+			box-sizing: border-box
+			margin: 0 4px
 </style>

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -17,6 +17,7 @@ bunt-input-outline-container.c-chat-input
 				a.chat-file(v-else :href="file.url" target="_blank")
 					i.bunt-icon.mdi.mdi-file
 					| {{ file.name }}
+		bunt-progress-circular(size="small" v-if="uploading")
 		bunt-icon-button#btn-remove-attachment(@click="files = null") close-circle
 	bunt-icon-button#btn-send(@click="send") send
 </template>
@@ -64,7 +65,8 @@ export default {
 	data () {
 		return {
 			showEmojiPicker: false,
-			files: null
+			files: null,
+			uploading: false
 		}
 	},
 	computed: {},
@@ -126,6 +128,8 @@ export default {
 			const files = Array.from(event.target.files)
 			if (files.length === 0) return
 
+			this.files = []
+			this.uploading = true
 			const requests = files.map(f => {
 				return api.uploadFilePromise(f, f.name)
 			})
@@ -140,6 +144,7 @@ export default {
 					}
 				}
 			})
+			this.uploading = false
 		},
 		addEmoji (emoji) {
 			// TODO skin color

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -7,7 +7,7 @@ bunt-input-outline-container.c-chat-input
 			path(d="M8 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 8 7M16 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 16 7M15.232 15c-.693 1.195-1.87 2-3.349 2-1.477 0-2.655-.805-3.347-2H15m3-2H6a6 6 0 1 0 12 0")
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
-	upload-button#btn-image.btn-image(@change="sendImage", accept="image/png, image/jpg, .png, .jpg, .jpeg", icon="image")
+	upload-button#btn-image.btn-image(@change="sendFiles", accept="image/png, image/jpg, .png, .jpg, .jpeg", icon="image", multiple=true)
 	bunt-icon-button#btn-send(@click="send") send
 </template>
 <script>
@@ -106,15 +106,20 @@ export default {
 			this.$emit('send', text)
 			this.quill.setContents([{insert: '\n'}])
 		},
-		sendImage (event) {
-			if (event.target.files.length !== 1) return
-			const imageFile = event.target.files[0]
+		async sendFiles (event) {
+			const files = Array.from(event.target.files)
+			if (files.length === 0) return
 
-			const request = api.uploadFile(imageFile, 'chat.jpg')
-			request.addEventListener('load', (event) => {
-				const response = JSON.parse(request.responseText)
-				this.$emit('sendImage', response.url)
+			const requests = files.map(f => {
+				return api.uploadFilePromise(f, 'chat.jpg')
 			})
+			const fileInfo = (await Promise.all(requests)).map((response, i) => {
+				return {
+					url: response.url,
+					mimeType: files[i].type
+				}
+			})
+			this.$emit('sendFiles', fileInfo)
 		},
 		addEmoji (emoji) {
 			// TODO skin color

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -8,18 +8,22 @@ bunt-input-outline-container.c-chat-input
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
 	upload-button#btn-file(@change="attachFiles", accept="image/png, image/jpg, application/pdf, .png, .jpg, .jpeg, .pdf", icon="paperclip", multiple=true)
-	.files-preview(v-if="files !== null || uploading")
+	bunt-icon-button#btn-send(@click="send") send
+	.files-preview(v-if="files.length > 0 || uploading")
 		template(v-for="file in files")
 			.chat-file(v-if="file === null")
 				i.bunt-icon.mdi.mdi-alert-circle.upload-error
+				bunt-icon-button#btn-remove-attachment(@click="files.pop(file)") close-circle
 			template(v-else)
-				img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
-				a.chat-file(v-else :href="file.url" target="_blank")
-					i.bunt-icon.mdi.mdi-file
-					| {{ file.name }}
+				.chat-image(v-if="file.mimeType.startsWith('image/')")
+					img(:src="file.url")
+					bunt-icon-button#btn-remove-attachment(@click="files.pop(file)") close-circle
+				.chat-file(v-else)
+					a.chat-file-content(:href="file.url" target="_blank")
+						i.bunt-icon.mdi.mdi-file
+						| {{ file.name }}
+					bunt-icon-button#btn-remove-attachment(@click="files.pop(file)") close-circle
 		bunt-progress-circular(size="small" v-if="uploading")
-		bunt-icon-button#btn-remove-attachment(@click="files = null") close-circle
-	bunt-icon-button#btn-send(@click="send") send
 </template>
 <script>
 /* global ENV_DEVELOPMENT */
@@ -65,7 +69,7 @@ export default {
 	data () {
 		return {
 			showEmojiPicker: false,
-			files: null,
+			files: [],
 			uploading: false
 		}
 	},
@@ -116,9 +120,9 @@ export default {
 				}
 			}
 			text = text.trim()
-			if (this.files !== null) {
+			if (this.files.length > 0) {
 				this.$emit('sendFiles', this.files.filter(it => it != null), text)
-				this.files = null
+				this.files = []
 			} else {
 				this.$emit('send', text)
 			}
@@ -143,11 +147,7 @@ export default {
 					}
 				}
 			})
-			if (this.files === null) {
-				this.files = fileInfos
-			} else {
-				Array.prototype.push.apply(this.files, fileInfos)
-			}
+			Array.prototype.push.apply(this.files, fileInfos)
 			this.uploading = false
 		},
 		addEmoji (emoji) {
@@ -251,28 +251,30 @@ export default {
 		icon-button-style(color: $clr-secondary-text-light)
 		height: 28px
 		width: 28px
+		background: white
 	.files-preview
-		position:absolute
-		top: 0;
-		margin-left: 28px
-		right: 8px
-		border-radius 4px 4px 0 0
+		position: relative
+		width: 100%
 		box-sizing: border-box
-		transform: translateY(-100%)
 		background white
-		border: 1px solid $clr-grey-400
-		border-bottom: none
-		padding: 8px
+		margin-top: 16px
 		.chat-image
+			position: relative
 			display: inline-block
 			width: 60px
 			height: 60px
-			object-fit: cover
 			box-sizing: border-box
 			border-radius 2px
 			border: 1px solid $clr-grey-400
-			margin: 0 4px
+			margin-right: 12px
+			margin-bottom: 12px
+			vertical-align: top
+			img
+				object-fit: cover
+				width: 100%
+				height: 100%
 		.chat-file
+			position: relative
 			display: inline-block
 			height: 60px
 			min-width 60px
@@ -280,12 +282,16 @@ export default {
 			text-align: center
 			border-radius 2px
 			border: 1px solid $clr-grey-400
-			text-overflow: ellipsis
-			overflow: hidden
-			white-space: nowrap
 			padding: 12px 8px
 			box-sizing: border-box
-			margin: 0 4px
+			margin-right: 12px
+			margin-bottom: 12px
+			vertical-align: top
 			.upload-error
 				color: $clr-danger
+			.chat-file-content
+				display: block
+				text-overflow: ellipsis
+				overflow: hidden
+				white-space: nowrap
 </style>

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -8,7 +8,7 @@ bunt-input-outline-container.c-chat-input
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
 	upload-button#btn-file(@change="attachFiles", accept="image/png, image/jpg, application/pdf, .png, .jpg, .jpeg, .pdf", icon="paperclip", multiple=true)
-	.files-preview(v-if="files !== null")
+	.files-preview(v-if="files !== null || uploading")
 		template(v-for="file in files")
 			.chat-file(v-if="file === null")
 				i.bunt-icon.mdi.mdi-alert-circle.upload-error
@@ -128,12 +128,11 @@ export default {
 			const files = Array.from(event.target.files)
 			if (files.length === 0) return
 
-			this.files = []
 			this.uploading = true
 			const requests = files.map(f => {
 				return api.uploadFilePromise(f, f.name)
 			})
-			this.files = (await Promise.all(requests)).map((response, i) => {
+			var fileInfos = (await Promise.all(requests)).map((response, i) => {
 				if (response.error) {
 					return null
 				} else {
@@ -144,6 +143,11 @@ export default {
 					}
 				}
 			})
+			if (this.files === null) {
+				this.files = fileInfos
+			} else {
+				Array.prototype.push.apply(this.files, fileInfos)
+			}
 			this.uploading = false
 		},
 		addEmoji (emoji) {

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -250,7 +250,7 @@ export default {
 	.files-preview
 		position:absolute
 		top: 0;
-		left: 28px
+		margin-left: 28px
 		right: 8px
 		border-radius 4px 4px 0 0
 		box-sizing: border-box

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -7,7 +7,7 @@ bunt-input-outline-container.c-chat-input
 			path(d="M8 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 8 7M16 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 16 7M15.232 15c-.693 1.195-1.87 2-3.349 2-1.477 0-2.655-.805-3.347-2H15m3-2H6a6 6 0 1 0 12 0")
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
-	upload-button#btn-image.btn-image(@change="sendFiles", accept="image/png, image/jpg, .png, .jpg, .jpeg", icon="image", multiple=true)
+	upload-button#btn-file(@change="sendFiles", accept="image/png, image/jpg, application/pdf, .png, .jpg, .jpeg, .pdf", icon="paperclip", multiple=true)
 	bunt-icon-button#btn-send(@click="send") send
 </template>
 <script>
@@ -111,12 +111,13 @@ export default {
 			if (files.length === 0) return
 
 			const requests = files.map(f => {
-				return api.uploadFilePromise(f, 'chat.jpg')
+				return api.uploadFilePromise(f, f.name)
 			})
 			const fileInfo = (await Promise.all(requests)).map((response, i) => {
 				return {
 					url: response.url,
-					mimeType: files[i].type
+					mimeType: files[i].type,
+					name: files[i].name
 				}
 			})
 			this.$emit('sendFiles', fileInfo)
@@ -204,7 +205,7 @@ export default {
 			font-size: 18px
 			height: 24px
 			line-height: @height
-	#btn-image
+	#btn-file
 		position: absolute
 		right: 32px
 		top: 4px

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -10,10 +10,13 @@ bunt-input-outline-container.c-chat-input
 	upload-button#btn-file(@change="attachFiles", accept="image/png, image/jpg, application/pdf, .png, .jpg, .jpeg, .pdf", icon="paperclip", multiple=true)
 	.files-preview(v-if="files !== null")
 		template(v-for="file in files")
-			img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
-			a.chat-file(v-else :href="file.url" target="_blank")
-				i.bunt-icon.mdi.mdi-file
-				| {{ file.name }}
+			.chat-file(v-if="file === null")
+				i.bunt-icon.mdi.mdi-alert-circle.upload-error
+			template(v-else)
+				img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
+				a.chat-file(v-else :href="file.url" target="_blank")
+					i.bunt-icon.mdi.mdi-file
+					| {{ file.name }}
 		bunt-icon-button#btn-remove-attachment(@click="files = null") close-circle
 	bunt-icon-button#btn-send(@click="send") send
 </template>
@@ -112,7 +115,7 @@ export default {
 			}
 			text = text.trim()
 			if (this.files !== null) {
-				this.$emit('sendFiles', this.files, text)
+				this.$emit('sendFiles', this.files.filter(it => it != null), text)
 				this.files = null
 			} else {
 				this.$emit('send', text)
@@ -127,10 +130,14 @@ export default {
 				return api.uploadFilePromise(f, f.name)
 			})
 			this.files = (await Promise.all(requests)).map((response, i) => {
-				return {
-					url: response.url,
-					mimeType: files[i].type,
-					name: files[i].name
+				if (response.error) {
+					return null
+				} else {
+					return {
+						url: response.url,
+						mimeType: files[i].type,
+						name: files[i].name
+					}
 				}
 			})
 		},
@@ -259,7 +266,9 @@ export default {
 		.chat-file
 			display: inline-block
 			height: 60px
+			min-width 60px
 			max-width: 100px
+			text-align: center
 			border-radius 2px
 			border: 1px solid $clr-grey-400
 			text-overflow: ellipsis
@@ -268,4 +277,6 @@ export default {
 			padding: 12px 8px
 			box-sizing: border-box
 			margin: 0 4px
+			.upload-error
+				color: $clr-danger
 </style>

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -7,6 +7,7 @@ bunt-input-outline-container.c-chat-input
 			path(d="M8 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 8 7M16 7a2 2 0 1 0-.001 3.999A2 2 0 0 0 16 7M15.232 15c-.693 1.195-1.87 2-3.349 2-1.477 0-2.655-.805-3.347-2H15m3-2H6a6 6 0 1 0 12 0")
 	.emoji-picker-blocker(v-if="showEmojiPicker", @click="showEmojiPicker = false")
 	emoji-picker(v-if="showEmojiPicker", @selected="addEmoji")
+	upload-button#btn-image.btn-image(@change="sendImage", accept="image/png, image/jpg, .png, .jpg, .jpeg", icon="image")
 	bunt-icon-button#btn-send(@click="send") send
 </template>
 <script>
@@ -15,9 +16,11 @@ bunt-input-outline-container.c-chat-input
 // - parse ascii emoticons ;)
 // - parse colol emoji :+1:
 // - add scrollbar when overflowing parent
+import api from 'lib/api'
 import Quill from 'quill'
 import 'quill/dist/quill.core.css'
 import EmojiPicker from 'components/EmojiPicker'
+import UploadButton from 'components/UploadButton'
 import { getEmojiPosition, nativeToOps, toNative } from 'lib/emoji'
 
 const Delta = Quill.import('delta')
@@ -44,7 +47,7 @@ EmojiBlot.tagName = 'img'
 Quill.register(EmojiBlot)
 
 export default {
-	components: { EmojiPicker },
+	components: { EmojiPicker, UploadButton },
 	props: {
 		message: Object // initialize with existing message to edit
 	},
@@ -103,6 +106,16 @@ export default {
 			this.$emit('send', text)
 			this.quill.setContents([{insert: '\n'}])
 		},
+		sendImage (event) {
+			if (event.target.files.length !== 1) return
+			const imageFile = event.target.files[0]
+
+			const request = api.uploadFile(imageFile, 'chat.jpg')
+			request.addEventListener('load', (event) => {
+				const response = JSON.parse(request.responseText)
+				this.$emit('sendImage', response.url)
+			})
+		},
 		addEmoji (emoji) {
 			// TODO skin color
 			this.showEmojiPicker = false
@@ -121,7 +134,7 @@ export default {
 	min-height: 36px
 	box-sizing: border-box
 	&.bunt-input-outline-container
-		padding: 8px 32px 6px 36px
+		padding: 8px 60px 6px 36px
 	.ql-editor
 		font-size: 16px
 		padding: 0
@@ -178,6 +191,17 @@ export default {
 	#btn-send
 		position: absolute
 		right: 4px
+		top: 4px
+		icon-button-style(color: $clr-secondary-text-light)
+		height: 28px
+		width: 28px
+		.bunt-icon
+			font-size: 18px
+			height: 24px
+			line-height: @height
+	#btn-image
+		position: absolute
+		right: 32px
 		top: 4px
 		icon-button-style(color: $clr-secondary-text-light)
 		height: 28px

--- a/webapp/src/components/ChatInput.vue
+++ b/webapp/src/components/ChatInput.vue
@@ -11,7 +11,7 @@ bunt-input-outline-container.c-chat-input
 	.files-preview(v-if="files !== null")
 		template(v-for="file in files")
 			img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
-			a.chat-file(v-else :href="file.url")
+			a.chat-file(v-else :href="file.url" target="_blank")
 				i.bunt-icon.mdi.mdi-file
 				| {{ file.name }}
 	bunt-icon-button#btn-send(@click="send") send

--- a/webapp/src/components/ChatMessage.vue
+++ b/webapp/src/components/ChatMessage.vue
@@ -16,8 +16,9 @@
 			template(v-if="message.content.type === 'files'")
 				.content
 					.file-message-part(v-for="file in message.content.files")
-						img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
-						a.chat-file(v-else :href="file.url")
+						a(:href="file.url" v-if="file.mimeType.startsWith('image/')" target="_blank")
+							img.chat-image(:src="file.url")
+						a.chat-file(v-else :href="file.url" target="_blank")
 							i.bunt-icon.mdi.mdi-file
 							| {{ file.name }}
 					span(v-if="message.content.body", v-html="content")

--- a/webapp/src/components/ChatMessage.vue
+++ b/webapp/src/components/ChatMessage.vue
@@ -13,6 +13,9 @@
 			template(v-if="message.content.type === 'text'")
 				chat-input(v-if="editing", :message="message", @send="editMessage")
 				.content(v-else, v-html="content")
+			template(v-if="message.content.type === 'image'")
+				.content
+					img.chat-image(:src="message.content.src")
 			.call(v-else-if="message.content.type === 'call'")
 				.prompt(v-if="message.sender === user.id") You started a video call
 				.prompt(v-else) {{ senderDisplayName }} invited you to a video call
@@ -22,7 +25,7 @@
 				template(v-slot:button="{toggle}")
 					bunt-icon-button(@click="toggle") dots-vertical
 				template(v-slot:menu)
-					.edit-message(v-if="message.sender === user.id", @click="startEditingMessage") {{ $t('ChatMessage:message-edit:label') }}
+					.edit-message(v-if="message.sender === user.id && message.content.type !== 'image'", @click="startEditingMessage") {{ $t('ChatMessage:message-edit:label') }}
 					.delete-message(@click="selected = false, showDeletePrompt = true") {{ $t('ChatMessage:message-delete:label') }}
 	template(v-else-if="message.event_type === 'channel.member'")
 		.system-content {{ sender.profile ? sender.profile.display_name : message.sender }} {{ message.content.membership === 'join' ? $t('ChatMessage:join-message:text') : $t('ChatMessage:leave-message:text') }}
@@ -212,6 +215,9 @@ export default {
 				display: inline-block
 				background-image: url("~emoji-datasource-twitter/img/twitter/sheets-256/64.png")
 				background-size: 5700% 5700%
+			.chat-image
+				max-width: calc(100% - 32px)
+				max-height: 300px
 		.call
 			border: border-separator()
 			border-radius: 6px

--- a/webapp/src/components/ChatMessage.vue
+++ b/webapp/src/components/ChatMessage.vue
@@ -13,9 +13,11 @@
 			template(v-if="message.content.type === 'text'")
 				chat-input(v-if="editing", :message="message", @send="editMessage")
 				.content(v-else, v-html="content")
-			template(v-if="message.content.type === 'image'")
+			template(v-if="message.content.type === 'files'")
 				.content
-					img.chat-image(:src="message.content.src")
+					.file-message-part(v-for="file in message.content.files")
+						img.chat-image(:src="file.url")
+					span(v-if="message.content.body", v-html="content")
 			.call(v-else-if="message.content.type === 'call'")
 				.prompt(v-if="message.sender === user.id") You started a video call
 				.prompt(v-else) {{ senderDisplayName }} invited you to a video call
@@ -25,7 +27,7 @@
 				template(v-slot:button="{toggle}")
 					bunt-icon-button(@click="toggle") dots-vertical
 				template(v-slot:menu)
-					.edit-message(v-if="message.sender === user.id && message.content.type !== 'image'", @click="startEditingMessage") {{ $t('ChatMessage:message-edit:label') }}
+					.edit-message(v-if="message.sender === user.id", @click="startEditingMessage") {{ $t('ChatMessage:message-edit:label') }}
 					.delete-message(@click="selected = false, showDeletePrompt = true") {{ $t('ChatMessage:message-delete:label') }}
 	template(v-else-if="message.event_type === 'channel.member'")
 		.system-content {{ sender.profile ? sender.profile.display_name : message.sender }} {{ message.content.membership === 'join' ? $t('ChatMessage:join-message:text') : $t('ChatMessage:leave-message:text') }}

--- a/webapp/src/components/ChatMessage.vue
+++ b/webapp/src/components/ChatMessage.vue
@@ -16,7 +16,10 @@
 			template(v-if="message.content.type === 'files'")
 				.content
 					.file-message-part(v-for="file in message.content.files")
-						img.chat-image(:src="file.url")
+						img.chat-image(:src="file.url" v-if="file.mimeType.startsWith('image/')")
+						a.chat-file(v-else :href="file.url")
+							i.bunt-icon.mdi.mdi-file
+							| {{ file.name }}
 					span(v-if="message.content.body", v-html="content")
 			.call(v-else-if="message.content.type === 'call'")
 				.prompt(v-if="message.sender === user.id") You started a video call

--- a/webapp/src/components/UploadButton.vue
+++ b/webapp/src/components/UploadButton.vue
@@ -6,7 +6,7 @@
 			.bunt-button-text
 				slot
 		ripple-ink
-	input#file-chooser(type="file", @change="$emit('change', $event)", :accept="accept")
+	input#file-chooser(type="file", @change="$emit('change', $event)", :accept="accept" :multiple="multiple")
 </template>
 <script>
 import RippleInk from 'buntpapier/src/mixins/ripple-ink'
@@ -18,6 +18,7 @@ export default {
 	],
 	props: {
 		accept: String,
+		multiple: Boolean,
 		tooltip: String,
 		icon: String,
 		tooltipPlacement: {

--- a/webapp/src/components/UploadButton.vue
+++ b/webapp/src/components/UploadButton.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
 .c-upload-button
-	label(for="file-chooser").bunt-button(v-tooltip="tooltipOptions || {text: _tooltip, placement: tooltipPlacement, fixed: tooltipFixed}")
+	label(for="file-chooser")(:class="_buttonClass", v-tooltip="tooltipOptions || {text: _tooltip, placement: tooltipPlacement, fixed: tooltipFixed}")
+		i.bunt-icon.mdi(v-if="iconClass()", :class="iconClass()")
 		.bunt-button-content
 			.bunt-button-text
 				slot
@@ -9,6 +10,7 @@
 </template>
 <script>
 import RippleInk from 'buntpapier/src/mixins/ripple-ink'
+import iconHelper from 'buntpapier/src/helpers/icon'
 
 export default {
 	mixins: [
@@ -17,6 +19,7 @@ export default {
 	props: {
 		accept: String,
 		tooltip: String,
+		icon: String,
 		tooltipPlacement: {
 			type: String,
 			default: 'bottom'
@@ -34,13 +37,29 @@ export default {
 	computed: {
 		_tooltip () {
 			return this.errorMessage ? this.errorMessage : this.tooltip
+		},
+		_buttonClass () {
+			return this.icon ? 'bunt-icon-button' : 'bunt-button'
 		}
 	},
-	methods: {}
+	methods: {
+		iconClass () {
+			if (!this.icon) return
+			return iconHelper.getClass(this.icon)
+		}
+	}
 }
 </script>
 <style lang="stylus">
 .c-upload-button
 	#file-chooser
 		display: none
+	.bunt-icon-button
+		pointer-events: auto
+		position: relative
+		top: 0
+		left: 0
+		transform: none
+		height: 100%
+		width: 100%
 </style>

--- a/webapp/src/lib/api.js
+++ b/webapp/src/lib/api.js
@@ -69,6 +69,21 @@ api.uploadFile = function (file, filename) {
 	return request
 }
 
+api.uploadFilePromise = function (file, filename) {
+	const data = new FormData()
+	data.append('file', file, filename)
+	const authHeader = api._config.token ? `Bearer ${api._config.token}`
+		: (api._config.clientId ? `Client ${api._config.clientId}` : null)
+	return fetch(config.api.upload, {
+		method: 'POST',
+		body: data,
+		headers: {
+			Accept: 'application/json',
+			Authorization: authHeader
+		}
+	}).then(response => response.json())
+}
+
 window.api = api
 
 export default api

--- a/webapp/src/store/chat.js
+++ b/webapp/src/store/chat.js
@@ -138,7 +138,7 @@ export default {
 				}
 			})
 		},
-		sendFiles ({state}, files, message) {
+		sendFiles ({state}, {files, message}) {
 			api.call('chat.send', {
 				channel: state.channel,
 				event_type: 'channel.message',

--- a/webapp/src/store/chat.js
+++ b/webapp/src/store/chat.js
@@ -138,6 +138,16 @@ export default {
 				}
 			})
 		},
+		sendImage ({state}, {src}) {
+			api.call('chat.send', {
+				channel: state.channel,
+				event_type: 'channel.message',
+				content: {
+					type: 'image',
+					src: src
+				}
+			})
+		},
 		deleteMessage ({state}, message) {
 			api.call('chat.send', {
 				channel: state.channel,

--- a/webapp/src/store/chat.js
+++ b/webapp/src/store/chat.js
@@ -138,13 +138,14 @@ export default {
 				}
 			})
 		},
-		sendImage ({state}, {src}) {
+		sendFiles ({state}, files, message) {
 			api.call('chat.send', {
 				channel: state.channel,
 				event_type: 'channel.message',
 				content: {
-					type: 'image',
-					src: src
+					type: 'files',
+					files: files,
+					body: message
 				}
 			})
 		},


### PR DESCRIPTION
A simple implementation for a "send image" button in chat rooms.
Pictures are uploaded using the existing upload mechanism (like for avatars) and displayed in the chat.

<img src="https://user-images.githubusercontent.com/5310424/96374780-22587380-1175-11eb-9502-66e3cfb39248.png" width=300/>

At the moment, it does not limit the size of uploaded pictures (as far as I know), or resize them in the browser like for avatars. That could probably still be implemented.

fixes #150 