### PR TITLE
Track and show online status of users

### DIFF
--- a/server/venueless/live/consumers.py
+++ b/server/venueless/live/consumers.py
@@ -109,7 +109,7 @@ class MainConsumer(AsyncJsonWebsocketConsumer):
 
         if content[0] == "ping":
             await self.send_json(["pong", content[1]])
-            self.last_conn_ping = await ping_connection(self.last_conn_ping)
+            self.last_conn_ping = await ping_connection(self.last_conn_ping, self.user)
             return
 
         if not self.user:

--- a/webapp/src/components/ChatUserCard.vue
+++ b/webapp/src/components/ChatUserCard.vue
@@ -4,6 +4,7 @@
 	.user-card(v-if="!userAction", v-scrollbar.y="", ref="card", @mousedown="showMoreActions=false")
 		avatar(:user="sender", :size="128")
 		.name
+			.online-status(:class="onlineStatus ? 'online' : (onlineStatus === false ? 'offline' : 'unknown')", v-tooltip="onlineStatus ? $t('UserAction:state.online:tooltip') : (onlineStatus === false ? $t('UserAction:state.offline:tooltip') : '')")
 			| {{ sender.profile ? sender.profile.display_name : (sender.id ? sender.id : '(unknown user)') }}
 			.ui-badge(v-for="badge in sender.badges") {{ badge }}
 		.fields(v-if="availableFields")
@@ -46,7 +47,8 @@ export default {
 			blockedUsers: null,
 			showMoreActions: false,
 			userAction: null,
-			moderationError: null
+			moderationError: null,
+			onlineStatus: null
 		}
 	},
 	computed: {
@@ -74,6 +76,7 @@ export default {
 		}
 	},
 	async created () {
+		this.onlineStatus = (await api.call('user.online_status', {ids: [this.sender.id]}))[this.sender.id]
 		this.blockedUsers = (await api.call('user.list.blocked')).users
 	},
 	methods: {
@@ -122,6 +125,19 @@ export default {
 					margin: 2px 0 0 8px
 		.state
 			height: 16px
+		.online-status
+			display: inline-block
+			margin-right: 8px
+			&::before
+				content: ''
+				display: inline-block
+				background-color: #ccc
+				width: 8px
+				height: 8px
+				border-radius: 50px
+				vertical-align: middle
+			&.online::before
+				background-color: $clr-success
 		.actions
 			margin-top: 16px
 			display: flex

--- a/webapp/src/locales/de.js
+++ b/webapp/src/locales/de.js
@@ -225,6 +225,8 @@ export default {
 	'UserAction:action.unblock:label': 'entblocken',
 	'UserAction:action.unsilence:label': 'stummschaltung aufheben',
 	'UserAction:moderator-actions:title': 'Moderatoraktionen',
+	'UserAction:state.offline:tooltip': 'offline',
+	'UserAction:state.online:tooltip': 'online',
 	'UserActionPrompt:action.ban:confirmation': 'Benutzer wurde gesperrt.',
 	'UserActionPrompt:action.ban:execute:label': 'sperren',
 	'UserActionPrompt:action.ban:explanation': 'Gesperrte Benutzer können nicht mehr an der Veranstaltung teilnehmen.',

--- a/webapp/src/locales/en.js
+++ b/webapp/src/locales/en.js
@@ -226,6 +226,8 @@ export default {
 	'UserAction:action.unblock:label': 'unblock',
 	'UserAction:action.unsilence:label': 'unsilence',
 	'UserAction:moderator-actions:title': 'Moderator Actions',
+	'UserAction:state.offline:tooltip': 'offline',
+	'UserAction:state.online:tooltip': 'online',
 	'UserActionPrompt:action.ban:confirmation': 'User has been banned.',
 	'UserActionPrompt:action.ban:execute:label': 'ban',
 	'UserActionPrompt:action.ban:explanation': 'Banning a user will completely prevent this user from entering the event.',

--- a/webapp/src/views/channels/item.vue
+++ b/webapp/src/views/channels/item.vue
@@ -1,18 +1,29 @@
 <template lang="pug">
 .c-channel
 	.ui-page-header
-		h2 {{ otherUsers.map(user => user.profile.display_name).join(', ') }}
+		h2
+			span.user(v-for="(u, key) in otherUsers")
+				span(v-if="key !== 0") {{ ', ' }}
+				.online-status(:class="onlineStatus[u.id] ? 'online' : (onlineStatus[u.id] === false ? 'offline' : 'unknown')", v-tooltip="onlineStatus[u.id] ? $t('UserAction:state.online:tooltip') : (onlineStatus[u.id] === false ? $t('UserAction:state.offline:tooltip') : '')")
+				span {{ u.profile.display_name }}
 		bunt-icon-button(@click="startCall", tooltip="start video call", tooltipPlacement="left") phone_outline
 	chat(mode="standalone", :module="{channel_id: channelId}", :showUserlist="false")
 </template>
 <script>
 import { mapState } from 'vuex'
+import api from 'lib/api'
 import Chat from 'components/Chat'
 
 export default {
 	components: { Chat },
 	props: {
 		channelId: String
+	},
+	data () {
+		return {
+			onlineStatus: {},
+			pollOnlineStatusStatusTimeout: null,
+		}
 	},
 	computed: {
 		...mapState(['user']),
@@ -24,10 +35,22 @@ export default {
 			return this.channel?.members.filter(member => member.id !== this.user.id)
 		}
 	},
+	async created () {
+		await this.pollOnlineStatus()
+	},
+	destroyed () {
+		if (this.pollOnlineStatusStatusTimeout) {
+			window.clearTimeout(this.pollOnlineStatusStatusTimeout)
+		}
+	},
 	methods: {
 		startCall () {
 			const channel = this.channel
 			this.$store.dispatch('chat/startCall', {channel})
+		},
+		async pollOnlineStatus () {
+			this.onlineStatus = (await api.call('user.online_status', {ids: this.otherUsers.map(u => u.id)}))
+			this.pollOnlineStatusStatusTimeout = window.setTimeout(this.pollOnlineStatus, 20000)
 		}
 	}
 }
@@ -44,6 +67,19 @@ export default {
 		justify-content: space-between
 		h2
 			margin: 0
+			.online-status
+				display: inline-block
+				margin-right: 8px
+				&::before
+					content: ''
+					display: inline-block
+					background-color: #ccc
+					width: 8px
+					height: 8px
+					border-radius: 50px
+					vertical-align: middle
+				&.online::before
+					background-color: $clr-success
 		.bunt-icon-button
 			icon-button-style(style: clear)
 </style>


### PR DESCRIPTION
It's pretty annoying to write DMs to users which are not logged in without any feedback. This PR is a light-weight approach to make each user's status accessible without adding to much messages and server load. The status of another user is polled when opening their profile card or in the DM tab (with polling every 20s, which certainly isn't elegant, but maybe even more efficient than trying to keep track of who is watching whos status)? Happy for comments.