### PR TITLE
Fix #156 -- Do not send notifications for messages that have already been read

### DIFF
--- a/webapp/src/store/chat.js
+++ b/webapp/src/store/chat.js
@@ -113,11 +113,11 @@ export default {
 		async markChannelRead ({state}) {
 			if (state.timeline.length === 0) return
 			const pointer = state.timeline[state.timeline.length - 1].event_id
+			Vue.set(state.readPointers, state.channel, pointer)
 			await api.call('chat.mark_read', {
 				channel: state.channel,
 				id: pointer
 			})
-			Vue.set(state.readPointers, state.channel, pointer)
 		},
 		async fetchUsers ({state}, ids) {
 			const users = await api.call('user.fetch', {ids})


### PR DESCRIPTION
As described in #156, when sending a DM message in some cases you might get a desktop notification and sound for your own message, which is really annoying. This is apparently a race condition in which ``mark_read`` completes only after the new unread pointers arrive, even though they are dispatched in the correct order. I first thought this required a server fix, but it turns out there's a *really simple* client fix. Only downside I can see to the fix is that the UI will have wrong state if ``chat.mark_read`` fails, but I'm not even sure that's a bad failure mode, since worst-case the read pointer isn't synced to other sessions but the local UI works fine. @rashfael do you think this is a good fix?