### PR TITLE
Simpler solution to postpone media after greeting dialog

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -23,7 +23,7 @@
 		rooms-sidebar(:show="$mq.above['l'] || showSidebar", @close="showSidebar = false")
 		router-view(:key="$route.fullPath")
 		//- defining keys like this keeps the playing dom element alive for uninterupted transitions
-		media-source(v-if="roomHasMedia", ref="primaryMediaSource", :room="room", :key="room.id")
+		media-source(v-if="roomHasMedia && user.profile.greeted", ref="primaryMediaSource", :room="room", :key="room.id")
 		media-source(v-if="call", ref="channelCallSource", :call="call", :background="call.channel !== $route.params.channelId", :key="call.id", @close="$store.dispatch('chat/leaveCall')")
 		media-source(v-else-if="backgroundRoom", ref="backgroundMediaSource", :room="backgroundRoom", :background="true", :key="backgroundRoom.id", @close="backgroundRoom = null")
 		notifications(:has-background-media="!!backgroundRoom")

--- a/webapp/src/components/BigBlueButton.vue
+++ b/webapp/src/components/BigBlueButton.vue
@@ -4,7 +4,6 @@
 </template>
 <script>
 import api from 'lib/api'
-
 export default {
 	props: {
 		room: {
@@ -22,17 +21,7 @@ export default {
 			error: null
 		}
 	},
-	computed: {
-		displayName () {
-			return this.$store.state.user.profile.display_name
-		}
-	},
 	watch: {
-		displayName () {
-			if (this.error) {
-				this.load()
-			}
-		},
 		background () {
 			if (!this.iframe) return
 			if (this.background) {
@@ -45,31 +34,25 @@ export default {
 	destroyed () {
 		this.iframe?.remove()
 	},
-	methods: {
-		async load () {
-			this.error = null
-			try {
-				const {url} = await api.call('bbb.room_url', {room: this.room.id})
-				if (!this.$el || this._isDestroyed) return
-				const iframe = document.createElement('iframe')
-				iframe.src = url
-				iframe.classList.add('bigbluebutton')
-				iframe.allow = 'camera; autoplay; microphone; fullscreen; display-capture'
-				iframe.allowfullscreen = true
-				iframe.allowusermedia = true
-				iframe.setAttribute('allowfullscreen', '') // iframe.allowfullscreen is not enough in firefox
-				const app = document.querySelector('#app')
-				app.appendChild(iframe)
-				this.iframe = iframe
-			} catch (error) {
-				// TODO handle bbb.join.missing_profile
-				this.error = error
-				console.log(error)
-			}
-		}
-	},
 	async created () {
-		await this.load()
+		try {
+			const {url} = await api.call('bbb.room_url', {room: this.room.id})
+			if (!this.$el || this._isDestroyed) return
+			const iframe = document.createElement('iframe')
+			iframe.src = url
+			iframe.classList.add('bigbluebutton')
+			iframe.allow = 'camera; autoplay; microphone; fullscreen; display-capture'
+			iframe.allowfullscreen = true
+			iframe.allowusermedia = true
+			iframe.setAttribute('allowfullscreen', '') // iframe.allowfullscreen is not enough in firefox
+			const app = document.querySelector('#app')
+			app.appendChild(iframe)
+			this.iframe = iframe
+		} catch (error) {
+			// TODO handle bbb.join.missing_profile
+			this.error = error
+			console.log(error)
+		}
 	}
 }
 </script>

--- a/webapp/src/components/JanusCall.vue
+++ b/webapp/src/components/JanusCall.vue
@@ -36,43 +36,26 @@ export default {
 		}
 	},
 	computed: {
-		displayName () {
-			return this.$store.state.user.profile.display_name
+	},
+	async created () {
+		this.loading = true
+		this.error = null
+		try {
+			const {server, roomId, token, sessionId, iceServers} = await api.call('januscall.room_url', {room: this.room.id})
+			if (!this.$el || this._isDestroyed) return
+			this.roomId = roomId
+			this.token = token
+			this.iceServers = iceServers
+			this.sessionId = sessionId
+			this.server = server
+		} catch (error) {
+			// TODO handle bbb.join.missing_profile
+			this.error = error
+			this.loading = false
+			console.log(error)
 		}
 	},
-	watch: {
-		displayName () {
-			if (this.error) {
-				this.load()
-			}
-		},
-	},
-	destroyed () {
-		this.iframe?.remove()
-	},
-	created () {
-		this.load()
-	},
 	methods: {
-		async load () {
-			this.loading = true
-			this.error = null
-			try {
-				const {server, roomId, token, sessionId, iceServers} = await api.call('januscall.room_url',
-					{room: this.room.id})
-				if (!this.$el || this._isDestroyed) return
-				this.roomId = roomId
-				this.token = token
-				this.iceServers = iceServers
-				this.sessionId = sessionId
-				this.server = server
-			} catch (error) {
-				// TODO handle bbb.join.missing_profile
-				this.error = error
-				this.loading = false
-				console.log(error)
-			}
-		},
 	},
 }
 </script>

--- a/webapp/src/components/Zoom.vue
+++ b/webapp/src/components/Zoom.vue
@@ -21,17 +21,7 @@ export default {
 			error: null
 		}
 	},
-	computed: {
-		displayName () {
-			return this.$store.state.user.profile.display_name
-		}
-	},
 	watch: {
-		displayName () {
-			if (this.error) {
-				this.load()
-			}
-		},
 		background () {
 			if (!this.iframe) return
 			if (this.background) {
@@ -44,30 +34,24 @@ export default {
 	destroyed () {
 		this.iframe?.remove()
 	},
-	created () {
-		this.load()
-	},
-	methods: {
-		async load () {
-			this.error = null
-			try {
-				const {url} = await api.call('zoom.room_url', {room: this.room.id})
-				if (!this.$el || this._isDestroyed) return
-				const iframe = document.createElement('iframe')
-				iframe.src = url
-				iframe.classList.add('zoom')
-				iframe.allow = 'camera; autoplay; microphone; fullscreen; display-capture'
-				iframe.allowfullscreen = true
-				iframe.allowusermedia = true
-				iframe.setAttribute('allowfullscreen', '') // iframe.allowfullscreen is not enough in firefox
-				const app = document.querySelector('#app')
-				app.appendChild(iframe)
-				this.iframe = iframe
-			} catch (error) {
-				// TODO handle zoom.join.missing_profile
-				this.error = error
-				console.log(error)
-			}
+	async created () {
+		try {
+			const {url} = await api.call('zoom.room_url', {room: this.room.id})
+			if (!this.$el || this._isDestroyed) return
+			const iframe = document.createElement('iframe')
+			iframe.src = url
+			iframe.classList.add('zoom')
+			iframe.allow = 'camera; autoplay; microphone; fullscreen; display-capture'
+			iframe.allowfullscreen = true
+			iframe.allowusermedia = true
+			iframe.setAttribute('allowfullscreen', '') // iframe.allowfullscreen is not enough in firefox
+			const app = document.querySelector('#app')
+			app.appendChild(iframe)
+			this.iframe = iframe
+		} catch (error) {
+			// TODO handle zoom.join.missing_profile
+			this.error = error
+			console.log(error)
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 64481386b2b34aaf66834e4b0ca9758f96d27355 and replaces it with a, uhm, 1-line solution. @rashfael Do you think this is cleaner? I think tying this to media-source makes sense at least for the current room types. 