### PR TITLE
[webapp] Do not send chat_read in volatile channels

### DIFF
--- a/webapp/src/store/chat.js
+++ b/webapp/src/store/chat.js
@@ -14,6 +14,7 @@ export default {
 		joinedChannels: null,
 		readPointers: null,
 		channel: null,
+		config: null,
 		members: [],
 		usersLookup: {},
 		timeline: [],
@@ -64,6 +65,7 @@ export default {
 			state.usersLookup = members.reduce((acc, member) => { acc[member.id] = member; return acc }, {})
 			state.timeline = []
 			state.beforeCursor = beforeCursor
+			state.config = config
 			if (getters.activeJoinedChannel) {
 				getters.activeJoinedChannel.notification_pointer = notificationPointer
 			}
@@ -113,6 +115,7 @@ export default {
 		},
 		async markChannelRead ({state}) {
 			if (state.timeline.length === 0) return
+			if (state.config?.volatile) return
 			const pointer = state.timeline[state.timeline.length - 1].event_id
 			await api.call('chat.mark_read', {
 				channel: state.channel,


### PR DESCRIPTION
Since we added statistics on what commands the server receives, it has been visible that ~80% of commands the server deals with are of type ``chat.mark_read``. This makes total sense, if there are 100 people on a channel and one posts a chat message, it will trigger 99 ``chat.mark_read`` calls.

Most of this traffic happens on stages, and we currently do not use read-state on stages for anything and I don't think we plan to.

These aren't expensive on the server side as they don't hit the SQL database, but they still cause some load that can grow even further with larger viewership numbers. So I propose a very simple change to just … not have that amount of traffic ;)