### PR TITLE
[server] Sort entries in dropdown of BBBMoveRoomForm

### DIFF
--- a/server/venueless/control/forms.py
+++ b/server/venueless/control/forms.py
@@ -235,5 +235,5 @@ class BBBMoveRoomForm(forms.Form):
         label="Room ID", queryset=Room.objects.all(), widget=forms.TextInput
     )
     server = forms.ModelChoiceField(
-        label="Target Server", queryset=BBBServer.objects.filter(active=True)
+        label="Target Server", queryset=BBBServer.objects.filter(active=True).order_by('url')
     )

--- a/server/venueless/control/forms.py
+++ b/server/venueless/control/forms.py
@@ -235,5 +235,6 @@ class BBBMoveRoomForm(forms.Form):
         label="Room ID", queryset=Room.objects.all(), widget=forms.TextInput
     )
     server = forms.ModelChoiceField(
-        label="Target Server", queryset=BBBServer.objects.filter(active=True).order_by('url')
+        label="Target Server",
+        queryset=BBBServer.objects.filter(active=True).order_by("url"),
     )


### PR DESCRIPTION
Tiny improvement that annoyed me in the new "move BBB room" feature:
The servers currently get listed in random order, which makes it annoying to select the right one, especially when moving several rooms. Therefore, order them by url.

I did this as a fun project and to learn a bit about how venueless is written.