### PR TITLE
Server-side image resizing at upload time

### DIFF
--- a/webapp/src/components/profile/ChangeAvatar.vue
+++ b/webapp/src/components/profile/ChangeAvatar.vue
@@ -91,14 +91,9 @@ export default {
 					return resolve()
 				}
 				if (!this.changedImage) return resolve()
-				const resizeCanvas = document.createElement('canvas')
-				resizeCanvas.width = MAX_AVATAR_SIZE
-				resizeCanvas.height = MAX_AVATAR_SIZE
 
-				const ctx = resizeCanvas.getContext('2d')
-				ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, MAX_AVATAR_SIZE, MAX_AVATAR_SIZE)
-				resizeCanvas.toBlob(blob => {
-					const request = api.uploadFile(blob, 'avatar.png')
+				canvas.toBlob(blob => {
+					const request = api.uploadFile(blob, 'avatar.png', null, MAX_AVATAR_SIZE, MAX_AVATAR_SIZE)
 					request.addEventListener('load', (event) => {
 						const response = JSON.parse(request.responseText)
 						this.$emit('input', {url: response.url})

--- a/webapp/src/lib/api.js
+++ b/webapp/src/lib/api.js
@@ -54,10 +54,12 @@ api.connect = function ({token, clientId}) {
 	})
 }
 
-api.uploadFile = function (file, filename, url) {
+api.uploadFile = function (file, filename, url, width, height) {
 	url = url || config.api.upload
 	const data = new FormData()
 	data.append('file', file, filename)
+	if (width) data.append('width', width)
+	if (height) data.append('height', height)
 	const request = new XMLHttpRequest()
 	request.open('POST', url)
 	request.setRequestHeader('Accept', 'application/json')


### PR DESCRIPTION
We've talked about this a few times before and we all agree that the optimal solution would be some kind of image resize proxy that allows us to store the images at full size and resize them to different sizes whenever the client needs them. I've looked into this multiple times and the existing solutions all do not fit our infrastructure architecture badly.

I've not given up on this, however I likely won't be able to solve it very soon, and we still have open customer complaints about the bad quality of the current avatars, which are resized on the client side. So this PR is a proposal to move this to server-side at upload time, which still has similar downsides as the current approach – but at least with a proper downsampling algorithm :)

@rashfael what do you think?