### PR TITLE
Fix link to Pretalx settings

### DIFF
--- a/webapp/src/views/admin/config/schedule.vue
+++ b/webapp/src/views/admin/config/schedule.vue
@@ -21,7 +21,7 @@
 					.pretalx-status.plugin-not-installed(v-if="!isPretalxPluginInstalled")
 						| pretalx-venueless plugin not installed/activated or domain + event not a valid pretalx instance.
 						br
-						| Please install and activate the plugin in #[a(:href="`${config.pretalx.domain}orga/event/${config.pretalx.event}/settings/plugins`", target="_blank") your pretalx event plugin settings].
+						| Please install and activate the plugin in #[a(:href="`${config.pretalx.domain}/orga/event/${config.pretalx.event}/settings/plugins`", target="_blank") your pretalx event plugin settings].
 					h3 Step 2: Connect pretalx to venueless
 					.pretalx-status(v-if="config.pretalx.connected") Pretalx-venueless connection active!
 					.pretalx-status.not-connected(v-else) Pretalx is not connected to venueless.


### PR DESCRIPTION
This PR fixes a link on the schedule page that configures integration with Pretalx. The link reference was missing a trailing slash after the full domain, so the resulting `href` would be `pretalx.comorga/` rather than `pretalx.com/orga`.
![Screenshot_2022-01-23_21-46-14](https://user-images.githubusercontent.com/10214785/150728936-d60a5ff5-879d-4b7b-ba81-6d444ba758ac.png)

