### PR TITLE
change rendering of external exhibitor links

### DIFF
--- a/webapp/src/views/exhibitors/item.vue
+++ b/webapp/src/views/exhibitors/item.vue
@@ -22,10 +22,9 @@ scrollbars.c-exhibitor(y)
 					h3.tagline(v-if="exhibitor.tagline") {{ exhibitor.tagline }}
 			.social-media-links(v-if="exhibitor.social_media_links.length > 0")
 				a.mdi(v-for="link in exhibitor.social_media_links", :class="`mdi-${link.display_text.toLowerCase()}`", :href="link.url", :title="link.display_text", target="_blank")
-			table.external-links(v-if="profileLinks.length > 0")
-				tr(v-for="link in profileLinks")
-					th.name {{ link.display_text }}
-					td: a(:href="link.url", target="_blank") {{ prettifyUrl(link.url) }}
+			.external-links(v-if="profileLinks.length > 0")
+				a(v-for="link of profileLinks", :href="link.url", target="_blank")
+					span {{ link.display_text || prettifyUrl(link.url) }}
 			.join-room(v-if="exhibitor.highlighted_room_id")
 				bunt-button(@click="joinRoom") {{ $t('Exhibition:room-button:label') }}
 			template(v-if="exhibitor.staff.length > 0")
@@ -215,20 +214,24 @@ export default {
 		.external-links
 			flex: none
 			border-bottom: border-separator()
-			tr
-				height: 24px
-			th
-				font-weight: 400
-				text-align: right
-			td
-				overflow: hidden
-				white-space: nowrap
-				text-overflow: ellipsis
-				max-width: 0
-				width: 100%
-			.name
-				white-space: nowrap
-			a:hover
+			display: flex
+			flex-direction: column
+			padding: 4px 8px
+			a
+				line-height: 24px
+				font-weight: 500
+				display: flex
+				align-items: center
+				span
+					ellipsis()
+				&::before
+					content: '\F03CC'
+					font-family: "Material Design Icons"
+					font-size: 18px
+					line-height: 24px
+					font-weight: 400
+					margin: 0 4px 0 0
+				&:hover span
 					text-decoration: underline
 		.contact, .join-room
 			flex: none


### PR DESCRIPTION
To make more space for the link label (which for some users might get pretty big), drop the prettified url and render the label as link text. The url will still be shown if no label is defined, for backwards compatibility.

Before:
![2022-05-08-20-46-42](https://user-images.githubusercontent.com/1093590/167311534-f5052174-1f22-46e4-8245-2dbba95ac509.png)
After:
![2022-05-08-21-00-25](https://user-images.githubusercontent.com/1093590/167311537-ee2c027d-e776-4101-a613-de331a01c247.png)
