### PR TITLE
Upgrade pandas

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -21,7 +21,7 @@ numpy==1.24.*
 orjson==3.9.*
 openpyxl~=3.1.2
 Pillow==10.1.*
-pandas~=1.3.5  # do not update, newer version wants us to use openpyxl instead of xlrd which has different error handling
+pandas==2.1.*
 pdf2image==1.16.*
 pdfrw==0.4
 pyjwt==2.8.*
@@ -33,7 +33,6 @@ requests==2.31.*
 sentry-sdk==1.30.*
 tqdm==4.66.*
 websockets==11.*
-xlrd~=1.2.0  # do not update, 2.x does not support .xlsx, only .xls
 
 # deploy
 psycopg2==2.9.9

--- a/server/venueless/storage/schedule_to_json.py
+++ b/server/venueless/storage/schedule_to_json.py
@@ -29,7 +29,7 @@ def load_sheet(io):
     }
     return {
         title: pandas.read_excel(
-            io, sheet_name=title, header=0, engine="xlrd", **config
+            io, sheet_name=title, header=0, engine="openpyxl", **config
         )
         for title, config in sheets.items()
     }

--- a/server/venueless/storage/views.py
+++ b/server/venueless/storage/views.py
@@ -15,7 +15,6 @@ from django.views.decorators.csrf import csrf_exempt
 from PIL import Image, ImageOps
 from PIL.Image import Resampling
 from rest_framework.authentication import get_authorization_header
-from xlrd import XLRDError
 
 from venueless.core.models import World
 from venueless.core.permissions import Permission
@@ -243,8 +242,6 @@ class ScheduleImportView(UploadMixin, View):
             jsondata = convert(request.FILES["file"], timezone=self.world.timezone)
         except ValidationError as e:
             return JsonResponse({"error": ", ".join(e)}, status=400)
-        except XLRDError as e:
-            return JsonResponse({"error": str(e)}, status=400)
         except ValueError as e:
             return JsonResponse({"error": str(e)}, status=400)
 


### PR DESCRIPTION
We currently use pandas to import schedule XLSX files and pandas currently uses xlrd for the excel parsing. However, recent pandas requires recent xlrd, and recent xlrd dropped XLSX support and only focuses on XLS support. For XLSX support, pandas now wants to use openpyxl. We have previously upgraded and then quickly downgraded again "because error handling broke". However, I have no memory of the way it broke.

Now, after upgrading to python 3.11, it becomes really annoying to be stuck on the old pandas version since there is no wheel published for it on PyPI and it makes our CI jobs and every other package installation incredibly slow because pandas needs to be compiled from scratch.

So I looked at it again and as far as I can tell… error handling seems fine?

@rixx Do you remember more about this? Can you also take it for a quick spin with wrongly formatted files and see if you get useful error messages?