### PR TITLE
Try to find the culprit for breaking tests

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,6 +28,7 @@ pyjwt==2.10.*
 python-dateutil==2.9.*
 pytz
 pywebpush==2.1.*
+pyopenssl==25.1.*
 redis==7.1.0
 reportlab==4.4.*
 requests==2.32.*


### PR DESCRIPTION
It's not vapid, it's not pywebpush directly … is it pyopenssl?