### PR TITLE
add raised-fist ✊ emoji to room reactions

### DIFF
--- a/server/venueless/live/modules/room.py
+++ b/server/venueless/live/modules/room.py
@@ -219,6 +219,7 @@ class RoomModule(BaseModule):
             "👏",
             "❤️",
             "👍",
+            "✊",
             "🤣",
             "😮",
         ):

--- a/webapp/src/components/ReactionsBar.vue
+++ b/webapp/src/components/ReactionsBar.vue
@@ -21,7 +21,7 @@ export default {
 	},
 	computed: {
 		availableReactions () {
-			const emoji = ['👏', '❤️', '👍', '🤣', '😮']
+			const emoji = ['👏', '❤️', '👍', '✊', '🤣', '😮']
 			return emoji.map(e => ({ emoji: e, style: nativeEmojiToStyle(e) }))
 		}
 	},


### PR DESCRIPTION
As noted by @pascoda, younger speakers/audiences might want to show their / be shown approval with different emoji.

It might make sense to have this be made customizable, should be easy enough.
I'll create this PR more as a feature request for now, we can talk about the default emoji set if we make room reactions configurable.