### PR TITLE
Bump redis from 7.4.0 to 8.0.0 in /server

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "python-dateutil==2.9.*",
     "pytz",
     "pywebpush==2.3.*",
-    "redis==7.4.0",
+    "redis==8.0.0",
     "reportlab==4.5.*",
     "requests==2.34.*",
     "sentry-sdk==2.61.*",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1703,11 +1703,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = "==2.9.*" },
     { name = "pytz" },
     { name = "pywebpush", specifier = "==2.3.*" },
-    { name = "redis", specifier = "==7.4.0" },
+    { name = "redis", specifier = "==8.0.0" },
     { name = "reportlab", specifier = "==4.5.*" },
     { name = "requests", specifier = "==2.34.*" },
     { name = "sentry-sdk", specifier = "==2.61.*" },

--- a/server/venueless/core/services/connections.py
+++ b/server/venueless/core/services/connections.py
@@ -13,10 +13,10 @@ async def register_connection():
             f"{settings.VENUELESS_COMMIT}.{settings.VENUELESS_ENVIRONMENT}",
             1,
         )
-        tr.setex(
+        tr.set(
             f"connections:{settings.VENUELESS_COMMIT}.{settings.VENUELESS_ENVIRONMENT}",
-            60,
             "exists",
+            ex=60,
         )
         await tr.execute()
 
@@ -77,10 +77,10 @@ async def ping_connection(last_ping, user=None):
                 f"connections.list.user:{user.id}",
                 90,
             )
-        tr.setex(
+        tr.set(
             f"connections:{settings.VENUELESS_COMMIT}.{settings.VENUELESS_ENVIRONMENT}",
-            60,
             "exists",
+            ex=60,
         )
         await tr.execute()
     return n

--- a/server/venueless/live/modules/chat.py
+++ b/server/venueless/live/modules/chat.py
@@ -479,8 +479,8 @@ class ChatModule(BaseModule):
                             str(user.id),
                         )
             async with aredis() as redis:
-                await redis.setex(
-                    f"chat:direct:shownall:{self.channel_id}", 3600 * 24 * 7, "true"
+                await redis.set(
+                    f"chat:direct:shownall:{self.channel_id}", "true", ex=3600 * 24 * 7
                 )
 
         event = await self.service.create_event(
@@ -747,8 +747,10 @@ class ChatModule(BaseModule):
                         )
             if not hide:
                 async with aredis() as redis:
-                    await redis.setex(
-                        f"chat:direct:shownall:{self.channel_id}", 3600 * 24 * 7, "true"
+                    await redis.set(
+                        f"chat:direct:shownall:{self.channel_id}",
+                        "true",
+                        ex=3600 * 24 * 7,
                     )
 
         reply["id"] = str(channel.id)

--- a/server/venueless/live/modules/room.py
+++ b/server/venueless/live/modules/room.py
@@ -185,8 +185,8 @@ class RoomModule(BaseModule):
     async def _update_view_count(self, room, actual_view_count):
         async with aredis(f"room:approxcount:known:{room.pk}") as redis:
             next_value = approximate_view_number(actual_view_count)
-            prev_value = await redis.getset(
-                f"room:approxcount:known:{room.pk}", next_value
+            prev_value = await redis.set(
+                f"room:approxcount:known:{room.pk}", next_value, get=True
             )
             if prev_value:
                 prev_value = prev_value.decode()


### PR DESCRIPTION
Supersedes #1043 and fixes new deprecation warnings by using new interfaces.